### PR TITLE
大砲の弾Fix

### DIFF
--- a/Assets/Prefabs/Exhibit/TestCannonBall.prefab
+++ b/Assets/Prefabs/Exhibit/TestCannonBall.prefab
@@ -341,7 +341,7 @@ MonoBehaviour:
   _cooldownTimeDictionary:
     keys: 04000000
     values:
-    - 0
+    - 1
   _characterEffects:
   - rid: 5083283266887483664
   _LastInteractTime: -9999
@@ -382,6 +382,7 @@ MonoBehaviour:
   _explosionRadius: 5
   _launchElapsedTime: 0
   _isAiming: 0
+  _cannonBallState: 0
 --- !u!54 &4885728260643230006
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Exhibit/TestCannonBall.prefab
+++ b/Assets/Prefabs/Exhibit/TestCannonBall.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6828188695797375861}
   - component: {fileID: 5889518820366247045}
+  - component: {fileID: 6249870148537539348}
   m_Layer: 0
   m_Name: Line
   m_TagString: Untagged
@@ -139,6 +140,21 @@ LineRenderer:
   m_UseWorldSpace: 0
   m_Loop: 0
   m_ApplyActiveColorSpace: 1
+--- !u!114 &6249870148537539348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3674208351796653040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3c5571c07b1e87145aa2bcf2dcf63758, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _lineRenderer: {fileID: 5889518820366247045}
+  _segmentCount: 30
+  _timeStep: 0.1
 --- !u!1 &4840829209715252854
 GameObject:
   m_ObjectHideFlags: 0
@@ -357,17 +373,16 @@ MonoBehaviour:
   _networkRigidbody3D: {fileID: 4192184776908821714}
   _interactableBase: {fileID: 782028490540396198}
   _modelCollider: {fileID: 3260869786553538935}
+  _trajectoryVisualizer: {fileID: 0}
   _power: 10
   _upwardForce: 1
   _damageAmount: 10
   _startPosition: {x: 0, y: -9.527, z: 19.326}
   _maxFlightTime: 3
-  _lineRenderer: {fileID: 5889518820366247045}
-  _segmentCount: 30
-  _timeStep: 0.1
+  _explosionRadius: 213.68
   _launchElapsedTime: 0
-  _state: 0
   _isAiming: 0
+  DebugState: 0
 --- !u!54 &4885728260643230006
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Exhibit/TestCannonBall.prefab
+++ b/Assets/Prefabs/Exhibit/TestCannonBall.prefab
@@ -329,6 +329,7 @@ MonoBehaviour:
   _characterEffects:
   - rid: 5083283266887483664
   _LastInteractTime: -9999
+  _ForceSetInteractable: 1
   references:
     version: 2
     RefIds:
@@ -355,6 +356,7 @@ MonoBehaviour:
   _networkObject: {fileID: 5978312770890431326}
   _networkRigidbody3D: {fileID: 4192184776908821714}
   _interactableBase: {fileID: 782028490540396198}
+  _modelCollider: {fileID: 3260869786553538935}
   _power: 10
   _upwardForce: 1
   _damageAmount: 10
@@ -365,6 +367,7 @@ MonoBehaviour:
   _timeStep: 0.1
   _launchElapsedTime: 0
   _state: 0
+  _isAiming: 0
 --- !u!54 &4885728260643230006
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Exhibit/TestCannonBall.prefab
+++ b/Assets/Prefabs/Exhibit/TestCannonBall.prefab
@@ -341,7 +341,7 @@ MonoBehaviour:
   _cooldownTimeDictionary:
     keys: 04000000
     values:
-    - 1
+    - 0
   _characterEffects:
   - rid: 5083283266887483664
   _LastInteractTime: -9999

--- a/Assets/Prefabs/Exhibit/TestCannonBall.prefab
+++ b/Assets/Prefabs/Exhibit/TestCannonBall.prefab
@@ -337,11 +337,11 @@ MonoBehaviour:
   _requiredInteractTimeDictionary:
     keys: 04000000
     values:
-    - 5
+    - 1
   _cooldownTimeDictionary:
     keys: 04000000
     values:
-    - 10
+    - 0
   _characterEffects:
   - rid: 5083283266887483664
   _LastInteractTime: -9999
@@ -379,10 +379,9 @@ MonoBehaviour:
   _damageAmount: 10
   _startPosition: {x: 0, y: -9.527, z: 19.326}
   _maxFlightTime: 3
-  _explosionRadius: 213.68
+  _explosionRadius: 5
   _launchElapsedTime: 0
   _isAiming: 0
-  DebugState: 0
 --- !u!54 &4885728260643230006
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Common/InputProvider.cs
+++ b/Assets/Scripts/Common/InputProvider.cs
@@ -14,6 +14,7 @@ namespace September.Common
         Dash,
         Interact,
         Attack,
+        Aim,
         Ability1,
         Ability2,
     }
@@ -53,6 +54,8 @@ namespace September.Common
             playerInput.Buttons.Set(PlayerButtons.Interact, playerActions.Interact.IsPressed());
             playerInput.Buttons.Set(PlayerButtons.Attack, playerActions.Attack.IsPressed());
             playerInput.Buttons.Set(PlayerButtons.Ability1, playerActions.Ability1.IsPressed());
+            playerInput.Buttons.Set(PlayerButtons.Ability2, playerActions.Ability2.IsPressed());
+            playerInput.Buttons.Set(PlayerButtons.Aim, playerActions.Aim.IsPressed());
             playerInput.MoveDirection = playerActions.Move.ReadValue<Vector2>();
             if (_mainCamera == null)
             {

--- a/Assets/Scripts/InGame/Common/Hitbox/MeleeHitboxExecutor.cs
+++ b/Assets/Scripts/InGame/Common/Hitbox/MeleeHitboxExecutor.cs
@@ -8,7 +8,7 @@ public class MeleeHitboxExecutor : IHitboxExecutor
     private readonly float _hitboxRadius;
     private readonly LayerMask _hitMask = default;
     private readonly HashSet<Collider> _alreadyHit = new();
-    private readonly RaycastHit[] _hitBuffer = new RaycastHit[32]; // バッファサイズは必要に応じて調整
+    private RaycastHit[] _hitBuffer = new RaycastHit[32]; // バッファサイズは必要に応じて調整
 
     private int _currentFrame;
     private readonly int _startFrame;
@@ -26,7 +26,7 @@ public class MeleeHitboxExecutor : IHitboxExecutor
     {
         _points = points ?? new List<Transform>();
         _hitboxRadius = hitboxRadius;
-        _hitMask = hitMask == default ? ~0 : hitMask;
+        _hitMask = hitMask == 0 ? ~0 : hitMask;
         _startFrame = startFrame;
         _endFrame = endFrame;
         _currentFrame = 0;
@@ -46,6 +46,16 @@ public class MeleeHitboxExecutor : IHitboxExecutor
         {
             ExecuteHitCheck();
         }
+    }
+    
+    public void SetHitBufferSize(int size)
+    {
+        const int minSize = 1;
+        const int maxSize = 100;
+        Debug.Assert(size is >= minSize and <= maxSize);
+
+        size = Mathf.Clamp(size, minSize, maxSize);
+        _hitBuffer = new RaycastHit[size];
     }
     
     public void ExecuteHitCheck()
@@ -73,6 +83,12 @@ public class MeleeHitboxExecutor : IHitboxExecutor
                     start, end, _hitboxRadius,
                     direction.normalized, _hitBuffer, distance,
                     _hitMask);
+                
+              
+                if (hitCount == _hitBuffer.Length)
+                {
+                    Debug.LogWarning($"[MeleeHitboxExecutor] ヒット数がバッファ上限（{_hitBuffer.Length}）に達しました。見逃しの可能性あり。");
+                }
 
                 for (int j = 0; j < hitCount; j++)
                 {
@@ -98,7 +114,7 @@ public class MeleeHitboxExecutor : IHitboxExecutor
 
     private void TrySphereCastSingle(Transform point)
     {
-        if (point == null) return;
+        if (!point) return;
 
         var origin = point.position;
         var direction = point.forward;
@@ -109,6 +125,11 @@ public class MeleeHitboxExecutor : IHitboxExecutor
         int hitCount = Physics.SphereCastNonAlloc(
             origin, _hitboxRadius, direction,
             _hitBuffer, fallbackDistance, _hitMask);
+        
+        if (hitCount == _hitBuffer.Length)
+        {
+            Debug.LogWarning($"[MeleeHitboxExecutor] ヒット数がバッファ上限（{_hitBuffer.Length}）に達しました。見逃しの可能性あり。");
+        }
 
         for (int j = 0; j < hitCount; j++)
         {

--- a/Assets/Scripts/InGame/Common/Hitbox/MeleeHitboxExecutor.cs
+++ b/Assets/Scripts/InGame/Common/Hitbox/MeleeHitboxExecutor.cs
@@ -47,8 +47,8 @@ public class MeleeHitboxExecutor : IHitboxExecutor
             ExecuteHitCheck();
         }
     }
-
-    private void ExecuteHitCheck()
+    
+    public void ExecuteHitCheck()
     {
         if (_points.Count == 1)
         {

--- a/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
+++ b/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
@@ -54,14 +54,12 @@ namespace InGame.Exhibit
         private int _equippedInteractor;
         private bool _shouldFollow;
         [Networked] private CannonBallState State { get; set; }
-        [SerializeField] CannonBallState DebugState;
         private EffectSpawner EffectSpawner => StaticServiceLocator.Instance.Get<EffectSpawner>();
         public event Action OnCannonBallHit;
         
         public override void Spawned() => InitializeCannonBall();
         private void Update()
         {
-            if (Object && Object.IsValid) DebugState = State;
             CheckHit();
         }
 
@@ -119,32 +117,40 @@ namespace InGame.Exhibit
             State = CannonBallState.Idle;
         }
 
+        int counter = 0;
         private void OnHitSomething(Collider hit)
         {
+            if (counter == 2)
+            {
+                Debug.Log("<UNK>");
+            }
+            // デバッグ用にカウンターを表示
+            counter++;
+            
             //とんでいないとき、弾の見た目のコリジョンに当たった時、投げた人自身にあたったときはそのまま
             if (State != CannonBallState.Launched || State == CannonBallState.Resetting || hit.gameObject == _model ||
                 hit.gameObject.GetComponentInParent<NetworkObject>()?.InputAuthority ==
                 _networkObject.InputAuthority) return;
 
-            Debug.Log($"{transform.position} で爆発しました。");
+            
             EffectSpawner.RequestPlayOneShotEffect(EffectType.Explosion, transform.position, Quaternion.identity);
-            _flyingHitBoxExecutor.ExecuteHitCheck();
+            _explodeHitBoxExecutor.ExecuteHitCheck();
             ResetCannonBall();
             OnCannonBallHit?.Invoke();
         }
         
         private void OnExplodeHit(Collider hit)
         {
-            Debug.Log($"[CannonBall] {hit.gameObject.name} に当たりました。");
             //とんでいないとき、弾の見た目のコリジョンに当たった時、投げた人自身にあたったときはそのまま
             if (State != CannonBallState.Launched || State == CannonBallState.Resetting || hit.gameObject == _model ||
                 hit.gameObject.GetComponentInParent<NetworkObject>()?.InputAuthority ==
                 _networkObject.InputAuthority) return;
 
-            //それ以外の何かに当たればぶつかった時の処理を行う。Damagableならダメージを与える
-            if (hit.TryGetComponent<IDamageable>(out var damageable) &&
+            var root = hit.transform.root;
+            if (root.TryGetComponent<IDamageable>(out var damageable) &&
                 damageable.OwnerPlayerRef != PlayerRef.FromEncoded(_equippedInteractor))
             {
+                Debug.Log($"[CannonBall] ダメージを与えます: {damageable.OwnerPlayerRef}");
                 var hitData = new HitData(HitActionType.Damage, _damageAmount,
                     PlayerRef.FromEncoded(_equippedInteractor), damageable.OwnerPlayerRef);
                 damageable.TakeHit(ref hitData);

--- a/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
+++ b/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
@@ -122,16 +122,8 @@ namespace InGame.Exhibit
             State = CannonBallState.Idle;
         }
 
-        int counter = 0;
         private void OnHitSomething(Collider hit)
         {
-            if (counter == 2)
-            {
-                Debug.Log("<UNK>");
-            }
-            // デバッグ用にカウンターを表示
-            counter++;
-            
             //とんでいないとき、弾の見た目のコリジョンに当たった時、投げた人自身にあたったときはそのまま
             if (State != CannonBallState.Launched || State == CannonBallState.Resetting || hit.gameObject == _model ||
                 hit.gameObject.GetComponentInParent<NetworkObject>()?.InputAuthority ==
@@ -236,6 +228,10 @@ namespace InGame.Exhibit
 
             _flyingHitBoxExecutor.Init();
             State = CannonBallState.Resetting;
+            if (_interactableBase.LastInteractTime < 0f)
+            {   // クールダウン時間が設定されていない場合は、Observableを使わずに直接StateをIdleにする
+                State = CannonBallState.Idle;
+            }
             _launchElapsedTime = 0f;
             _networkObject.RemoveInputAuthority();
             Rpc_SetModelAdulationTarget();

--- a/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
+++ b/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cinemachine;
 using Fusion;
 using Fusion.Addons.Physics;
 using InGame.Health;
@@ -41,19 +42,22 @@ namespace InGame.Exhibit
         [SerializeField] private int _damageAmount = 10;
         [SerializeField] private Vector3 _startPosition;
         [SerializeField] private float _maxFlightTime = 3f;
+        [SerializeField] private float _explosionRadius = 5f;
 
         [Header("デバッグ")]
         [SerializeField] private float _launchElapsedTime;
         [SerializeField] private bool _isAiming;
+        private MeleeHitboxExecutor _flyingHitBoxExecutor;
+        private MeleeHitboxExecutor _explodeHitBoxExecutor;
         private Transform _currentOwnerTransform;     // 投げ方向用
         private Transform _followTargetTransform;     // 見た目追従用
-        private bool _shouldFollow = false;
         private int _equippedInteractor;
-        private MeleeHitboxExecutor _meleeHitboxExecutor;
+        private bool _shouldFollow;
         [Networked] private CannonBallState State { get; set; }
         [SerializeField] CannonBallState DebugState;
         private EffectSpawner EffectSpawner => StaticServiceLocator.Instance.Get<EffectSpawner>();
         public event Action OnCannonBallHit;
+        
         public override void Spawned() => InitializeCannonBall();
         private void Update()
         {
@@ -61,8 +65,21 @@ namespace InGame.Exhibit
             CheckHit();
         }
 
-        public override void FixedUpdateNetwork() => GetFireInput();
-        
+        public override void FixedUpdateNetwork()
+        {
+            GetFireInput();
+            // if (GetInput(out PlayerInput input) && input.Buttons.IsSet(PlayerButtons.Aim))
+            // {
+            //     _isAiming = true;
+            //     //FOVを上げる
+            //     
+            // }
+            // else
+            // {
+            //     _isAiming = false;
+            // }
+        }
+
         private void LateUpdate()
         {
             ShowTrajectory();
@@ -85,7 +102,6 @@ namespace InGame.Exhibit
         private void InitializeCannonBall()
         {
             _networkRigidbody3D.RBIsKinematic = true;
-            _meleeHitboxExecutor = new MeleeHitboxExecutor(new List<Transform>() { _model.transform }, hitboxRadius: _model.transform.localScale.x * 0.5f);
 
             Observable.EveryUpdate()
                 .Select(_ => _interactableBase.IsInCooldown())
@@ -95,17 +111,36 @@ namespace InGame.Exhibit
                     State = inCoolDown ? CannonBallState.Resetting : CannonBallState.Idle;
                 }).AddTo(this);
 
+            _flyingHitBoxExecutor = new MeleeHitboxExecutor(new List<Transform>() { _model.transform }, hitboxRadius: _model.transform.localScale.x * 0.5f);
+            _flyingHitBoxExecutor.OnHit += OnHitSomething;
+            _explodeHitBoxExecutor = new MeleeHitboxExecutor(new List<Transform>() { transform }, hitboxRadius: _explosionRadius);
+            _explodeHitBoxExecutor.OnHit += OnExplodeHit;
+            
             State = CannonBallState.Idle;
-            _meleeHitboxExecutor.OnHit += OnHitSomething;
         }
 
         private void OnHitSomething(Collider hit)
         {
             //とんでいないとき、弾の見た目のコリジョンに当たった時、投げた人自身にあたったときはそのまま
-            if (State != CannonBallState.Launched || hit.gameObject == _model ||
+            if (State != CannonBallState.Launched || State == CannonBallState.Resetting || hit.gameObject == _model ||
                 hit.gameObject.GetComponentInParent<NetworkObject>()?.InputAuthority ==
                 _networkObject.InputAuthority) return;
-            
+
+            Debug.Log($"{transform.position} で爆発しました。");
+            EffectSpawner.RequestPlayOneShotEffect(EffectType.Explosion, transform.position, Quaternion.identity);
+            _flyingHitBoxExecutor.ExecuteHitCheck();
+            ResetCannonBall();
+            OnCannonBallHit?.Invoke();
+        }
+        
+        private void OnExplodeHit(Collider hit)
+        {
+            Debug.Log($"[CannonBall] {hit.gameObject.name} に当たりました。");
+            //とんでいないとき、弾の見た目のコリジョンに当たった時、投げた人自身にあたったときはそのまま
+            if (State != CannonBallState.Launched || State == CannonBallState.Resetting || hit.gameObject == _model ||
+                hit.gameObject.GetComponentInParent<NetworkObject>()?.InputAuthority ==
+                _networkObject.InputAuthority) return;
+
             //それ以外の何かに当たればぶつかった時の処理を行う。Damagableならダメージを与える
             if (hit.TryGetComponent<IDamageable>(out var damageable) &&
                 damageable.OwnerPlayerRef != PlayerRef.FromEncoded(_equippedInteractor))
@@ -114,11 +149,6 @@ namespace InGame.Exhibit
                     PlayerRef.FromEncoded(_equippedInteractor), damageable.OwnerPlayerRef);
                 damageable.TakeHit(ref hitData);
             }
-
-            Debug.Log($"{hit.gameObject.name} にヒット");
-            EffectSpawner.RequestPlayOneShotEffect(EffectType.Explosion, transform.position, Quaternion.identity);
-            ResetCannonBall();
-            OnCannonBallHit?.Invoke();
         }
 
         /// <summary>
@@ -158,7 +188,7 @@ namespace InGame.Exhibit
         private void CheckHit()
         {
             if (!HasStateAuthority || State != CannonBallState.Launched) return;
-            _meleeHitboxExecutor.Tick(Time.deltaTime);
+            _flyingHitBoxExecutor.Tick(Time.deltaTime);
 
             _launchElapsedTime += Time.deltaTime;
             if (_launchElapsedTime < _maxFlightTime) return;    // 飛行時間が最大を超えたらリセット
@@ -193,7 +223,7 @@ namespace InGame.Exhibit
             _networkRigidbody3D.RBIsKinematic = true;
             _networkRigidbody3D.Teleport(_startPosition);
 
-            _meleeHitboxExecutor.Init();
+            _flyingHitBoxExecutor.Init();
             State = CannonBallState.Resetting;
             _launchElapsedTime = 0f;
             _networkObject.RemoveInputAuthority();

--- a/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
+++ b/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
@@ -13,48 +13,76 @@ using UnityEngine;
 
 namespace InGame.Exhibit
 {
+    /// <summary>
+    /// 大砲の砲丸を表現するクラス
+    /// </summary>
     public class CannonBall : NetworkBehaviour
     {
-        public enum CannonBallState
+        private enum CannonBallState
         {
             Idle,
+            Equipped,
             Launched,
             Resetting
         }
-        
+
         [Header("参照")]
         [SerializeField] private GameObject _model;
         [SerializeField] private Rigidbody _rigidbody;
         [SerializeField] private NetworkObject _networkObject;
         [SerializeField] private NetworkRigidbody3D _networkRigidbody3D;
         [SerializeField] private InteractableBase _interactableBase;
+        [SerializeField] private Collider _modelCollider;
+        [SerializeField] private TrajectoryVisualizer _trajectoryVisualizer;
 
         [Header("設定")]
         [SerializeField] private float _power = 10f;
         [SerializeField] private float _upwardForce = 5f;
         [SerializeField] private int _damageAmount = 10;
         [SerializeField] private Vector3 _startPosition;
-        [SerializeField] private float _maxFlightTime = 3f; // 飛行最大時間（秒）
-        
-        [Header("放物線描画設定")]
-        [SerializeField] private LineRenderer _lineRenderer;
-        [SerializeField] private int _segmentCount = 30;
-        [SerializeField] private float _timeStep = 0.1f;
-        
+        [SerializeField] private float _maxFlightTime = 3f;
+
         [Header("デバッグ")]
         [SerializeField] private float _launchElapsedTime;
-        [SerializeField] private CannonBallState _state = CannonBallState.Idle;
-        [SerializeField] private bool _isAiming = false;
-        private Transform _currentOwnerTransform;
+        [SerializeField] private bool _isAiming;
+        private Transform _currentOwnerTransform;     // 投げ方向用
+        private Transform _followTargetTransform;     // 見た目追従用
+        private bool _shouldFollow = false;
         private int _equippedInteractor;
         private MeleeHitboxExecutor _meleeHitboxExecutor;
+        [Networked] private CannonBallState State { get; set; }
+        [SerializeField] CannonBallState DebugState;
         private EffectSpawner EffectSpawner => StaticServiceLocator.Instance.Get<EffectSpawner>();
-
         public event Action OnCannonBallHit;
+        public override void Spawned() => InitializeCannonBall();
+        private void Update()
+        {
+            if (Object && Object.IsValid) DebugState = State;
+            CheckHit();
+        }
 
-       
+        public override void FixedUpdateNetwork() => GetFireInput();
+        
+        private void LateUpdate()
+        {
+            ShowTrajectory();
+            TrackModelToFollowTarget();
+            if (Object && Object.IsValid) _model.SetActive(State != CannonBallState.Resetting);
+        }
 
-        public override void Spawned()
+        public void EquipToInteractor(int interactor)
+        {
+            var playerRef = PlayerRef.FromEncoded(interactor);
+            _networkObject.AssignInputAuthority(playerRef);
+            State = CannonBallState.Equipped;
+            Rpc_SetModelAdulationTarget(interactor);
+        }
+
+        /// <summary>
+        /// 空中での固定、当たり判定クラスの生成、クールダウン開始＆終了時にStateを更新する処理の登録、何かに当たった時の処理の登録
+        /// を行う。
+        /// </summary>
+        private void InitializeCannonBall()
         {
             _networkRigidbody3D.RBIsKinematic = true;
             _meleeHitboxExecutor = new MeleeHitboxExecutor(new List<Transform>() { _model.transform }, hitboxRadius: _model.transform.localScale.x * 0.5f);
@@ -64,191 +92,138 @@ namespace InGame.Exhibit
                 .DistinctUntilChanged()
                 .Subscribe(inCoolDown =>
                 {
-                    _state = inCoolDown ? CannonBallState.Resetting : CannonBallState.Idle;
-                    Rpc_SetCannonBallVisible(!inCoolDown); // クールダウン中は非表示
+                    State = inCoolDown ? CannonBallState.Resetting : CannonBallState.Idle;
                 }).AddTo(this);
+
+            State = CannonBallState.Idle;
+            _meleeHitboxExecutor.OnHit += OnHitSomething;
+        }
+
+        private void OnHitSomething(Collider hit)
+        {
+            //とんでいないとき、弾の見た目のコリジョンに当たった時、投げた人自身にあたったときはそのまま
+            if (State != CannonBallState.Launched || hit.gameObject == _model ||
+                hit.gameObject.GetComponentInParent<NetworkObject>()?.InputAuthority ==
+                _networkObject.InputAuthority) return;
             
-            _meleeHitboxExecutor.OnHit += hit =>
+            //それ以外の何かに当たればぶつかった時の処理を行う。Damagableならダメージを与える
+            if (hit.TryGetComponent<IDamageable>(out var damageable) &&
+                damageable.OwnerPlayerRef != PlayerRef.FromEncoded(_equippedInteractor))
             {
-                var didHitSomething = false;
-                if (hit.gameObject == _model) return; // 自分自身には当たらないように
-                if (hit.TryGetComponent<IDamageable>(out var damageable))
-                {
-                    if (damageable.OwnerPlayerRef != PlayerRef.FromEncoded(_equippedInteractor))
-                    {
-                        var hitData = new HitData(HitActionType.Damage, _damageAmount, PlayerRef.FromEncoded(_equippedInteractor), damageable.OwnerPlayerRef);
-                        damageable.TakeHit(ref hitData);
-                        didHitSomething = true;
-                    }
-                }
-                else
-                {
-                    if (hit.gameObject.GetComponentInParent<NetworkObject>()?.InputAuthority == _networkObject.InputAuthority)
-                        return; // 自分のものには当たらないように
-                    // IDamageable ではないが何かに当たった場合もヒット扱い
-                    didHitSomething = true;
-                }
+                var hitData = new HitData(HitActionType.Damage, _damageAmount,
+                    PlayerRef.FromEncoded(_equippedInteractor), damageable.OwnerPlayerRef);
+                damageable.TakeHit(ref hitData);
+            }
 
-                if (didHitSomething && _state == CannonBallState.Launched)
-                {
-                    Debug.Log( $"{hit.gameObject.name} にヒット");
-                    EffectSpawner.RequestPlayOneShotEffect(EffectType.Explosion, transform.position, Quaternion.identity);
-                    Rpc_ResetCannonBall(); // 全体にリセット
-                    OnCannonBallHit?.Invoke();
-                }
-            };
+            Debug.Log($"{hit.gameObject.name} にヒット");
+            EffectSpawner.RequestPlayOneShotEffect(EffectType.Explosion, transform.position, Quaternion.identity);
+            ResetCannonBall();
+            OnCannonBallHit?.Invoke();
         }
 
-        public void EquipToInteractor(int interactor)
-        {
-            var playerRef = PlayerRef.FromEncoded(interactor);
-            _networkObject.AssignInputAuthority(playerRef);
-            Rpc_SetModelParent(interactor);
-        }
-
+        /// <summary>
+        /// モデルの追従先を設定するRPC。-1で見た目用オブジェクトが大砲の弾事態に追従する
+        /// それ以外の時は、指定されたインタラクターの手に追従する。
+        /// </summary>
+        /// <param name="interactor"></param>
         [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
-        private void Rpc_SetModelParent(int interactor)
+        private void Rpc_SetModelAdulationTarget(int interactor = -1)
         {
-            Debug.Log(interactor);
             if (interactor == -1)
             {
-                _model.transform.SetParent(transform);
-                _model.transform.localPosition = Vector3.zero;
+                _modelCollider.enabled = true;
+                _model.transform.position = transform.position;
+                _model.transform.rotation = transform.rotation;
                 _currentOwnerTransform = null;
+                _followTargetTransform = null;
                 _equippedInteractor = -1;
-                return;
-            }
-            
-            var playerRef = PlayerRef.FromEncoded(interactor);
-            if (Runner.TryGetPlayerObject(playerRef, out var playerObj))
-            {
-                var hand = playerObj.GetComponentInChildren<HandSocket>()?.Sockets.FirstOrDefault();
-                if (hand)
-                {
-                    _model.transform.SetParent(hand);
-                    _model.transform.localPosition = Vector3.zero;
-                    _model.transform.localRotation = Quaternion.identity;
-                    _currentOwnerTransform = playerObj.transform;
-                    _equippedInteractor = interactor;
-                }
-            }
-        }
-
-        private void Update()
-        {
-            
-            if (Runner?.IsServer == false) return;
-            
-            if (_state == CannonBallState.Launched && HasStateAuthority)
-            {
-                _meleeHitboxExecutor.Tick(Time.deltaTime);
-
-                _launchElapsedTime += Time.deltaTime;
-                if (_launchElapsedTime > _maxFlightTime)
-                {
-                    Rpc_ResetCannonBall();
-                    OnCannonBallHit?.Invoke(); // optional: 飛行時間オーバーでのエフェクトなど
-                }
-            }
-        }
-
-        public override void FixedUpdateNetwork()
-        {
-            if (!GetInput(out PlayerInput input) || _state == CannonBallState.Launched) return;
-
-            if (input.Buttons.IsSet(PlayerButtons.Attack))
-            {
-                _networkRigidbody3D.Teleport(_model.transform.position);
-                _networkRigidbody3D.RBIsKinematic = false;
-
-                // 斜め上方向に投げるベクトルを作成
-                var forward = _currentOwnerTransform.forward;
-                var upward = _currentOwnerTransform.up;
-                var throwDir = (forward + upward * _upwardForce).normalized;
-                _rigidbody.AddForce(throwDir * _power, ForceMode.Impulse);
-
-                Rpc_SetModelParent(-1);
-                Rpc_Launch();
-            }
-        }
-
-        [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
-        private void Rpc_Launch()
-        {
-            _state = CannonBallState.Launched;
-        }
-
-        [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
-        private void Rpc_ResetCannonBall()
-        {
-            _networkRigidbody3D.RBIsKinematic = true;
-            _networkRigidbody3D.Teleport(_startPosition);
-            
-            Rpc_SetModelParent(-1);
-            _meleeHitboxExecutor.Init();
-            _state = CannonBallState.Resetting;
-            _launchElapsedTime = 0f;
-            _networkObject.RemoveInputAuthority();
-            Rpc_SetCannonBallVisible(false);
-        }
-        
-        [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
-        private void Rpc_SetCannonBallVisible(bool isVisible)
-        {
-            if (_model != null)
-            {
-                _model.SetActive(isVisible);
-            }
-        }
-        
-        #region 放物線描画
-
-        private void LateUpdate()
-        {
-            if (_isAiming && _currentOwnerTransform)
-            {
-                ShowTrajectory();
             }
             else
             {
-                _lineRenderer.enabled = false;
+                var playerRef = PlayerRef.FromEncoded(interactor);
+                if (!Runner.TryGetPlayerObject(playerRef, out var playerObj)) return;
+                var hand = playerObj.GetComponentInChildren<HandSocket>()?.Sockets.FirstOrDefault();
+                if (!hand) return;
+                _modelCollider.enabled = false;
+                _currentOwnerTransform = playerObj.transform;
+                _followTargetTransform = hand;
+                _equippedInteractor = interactor;
+                _shouldFollow = true;
             }
+        }
+
+        /// <summary>
+        /// ホストでとんでいるときだけ当たり判定を行う
+        /// </summary>
+        private void CheckHit()
+        {
+            if (!HasStateAuthority || State != CannonBallState.Launched) return;
+            _meleeHitboxExecutor.Tick(Time.deltaTime);
+
+            _launchElapsedTime += Time.deltaTime;
+            if (_launchElapsedTime < _maxFlightTime) return;    // 飛行時間が最大を超えたらリセット
+            ResetCannonBall();
+            OnCannonBallHit?.Invoke();
+        }
+
+        private void GetFireInput()
+        {
+            //入力がない、または攻撃ボタンが押されていない、またはすでに発射済みなら何もしない
+            if (!GetInput(out PlayerInput input) || !input.Buttons.IsSet(PlayerButtons.Attack) || State == CannonBallState.Launched) return;
+            if (!_currentOwnerTransform)
+            {
+                Debug.LogWarning("[CannonBall] 現在の所有者のTransformが設定されていません。");
+                return;
+            }
+
+            // 向きを先に計算
+            var forward = _currentOwnerTransform.forward;
+            var upward = _currentOwnerTransform.up;
+            var throwDir = (forward + upward * _upwardForce).normalized;
+            _networkRigidbody3D.Teleport(_model.transform.position);
+            _networkRigidbody3D.RBIsKinematic = false;
+            _rigidbody.AddForce(throwDir * _power, ForceMode.Impulse);
+
+            Rpc_SetModelAdulationTarget();
+            State = CannonBallState.Launched;
+        }
+
+        private void ResetCannonBall()
+        {
+            _networkRigidbody3D.RBIsKinematic = true;
+            _networkRigidbody3D.Teleport(_startPosition);
+
+            _meleeHitboxExecutor.Init();
+            State = CannonBallState.Resetting;
+            _launchElapsedTime = 0f;
+            _networkObject.RemoveInputAuthority();
+            Rpc_SetModelAdulationTarget();
         }
 
         private void ShowTrajectory()
         {
-            Vector3 startPos = _model.transform.position;
-            Vector3 forward = _currentOwnerTransform.forward;
-            Vector3 upward = _currentOwnerTransform.up;
-            Vector3 velocity = (forward + upward * _upwardForce).normalized * _power;
-
-            Vector3[] points = new Vector3[_segmentCount];
-            Vector3 currentPosition = startPos;
-            Vector3 currentVelocity = velocity;
-
-            for (int i = 0; i < _segmentCount; i++)
+            if (_isAiming && _currentOwnerTransform)
             {
-                points[i] = currentPosition;
+                var startPos = _model.transform.position;
+                var forward = _currentOwnerTransform.forward;
+                var upward = _currentOwnerTransform.up;
+                var velocity = (forward + upward * _upwardForce).normalized * _power;
 
-                // 簡易物理シミュレーション
-                currentVelocity += Physics.gravity * _timeStep;
-                Vector3 nextPosition = currentPosition + currentVelocity * _timeStep;
-
-                // 衝突チェック（optional）
-                if (Physics.Linecast(currentPosition, nextPosition, out var hit))
-                {
-                    points[i + 1 >= _segmentCount ? i : i + 1] = hit.point;
-                    _lineRenderer.positionCount = i + 2;
-                    break;
-                }
-
-                currentPosition = nextPosition;
+                _trajectoryVisualizer?.ShowTrajectory(startPos, velocity);
             }
-
-            _lineRenderer.enabled = true;
-            _lineRenderer.SetPositions(points);
+            else
+            {
+                _trajectoryVisualizer?.Hide();
+            }
         }
 
-        #endregion
+        private void TrackModelToFollowTarget()
+        {
+            if (_shouldFollow && _followTargetTransform)
+            {
+                _model.transform.position = _followTargetTransform.position;
+                _model.transform.rotation = _followTargetTransform.rotation;
+            }
+        }
     }
 }

--- a/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
+++ b/Assets/Scripts/InGame/Exhibit/CannonBall/CannonBall.cs
@@ -47,6 +47,7 @@ namespace InGame.Exhibit
         [Header("デバッグ")]
         [SerializeField] private float _launchElapsedTime;
         [SerializeField] private bool _isAiming;
+        [SerializeField] private CannonBallState _cannonBallState = CannonBallState.Idle;
         private MeleeHitboxExecutor _flyingHitBoxExecutor;
         private MeleeHitboxExecutor _explodeHitBoxExecutor;
         private Transform _currentOwnerTransform;     // 投げ方向用
@@ -61,6 +62,10 @@ namespace InGame.Exhibit
         private void Update()
         {
             CheckHit();
+            if (Object && Object.IsValid)
+            {
+                _cannonBallState = State;
+            }
         }
 
         public override void FixedUpdateNetwork()

--- a/Assets/Scripts/InGame/Exhibit/CannonBall/Trajectory.cs
+++ b/Assets/Scripts/InGame/Exhibit/CannonBall/Trajectory.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+namespace InGame.Exhibit
+{
+    /// <summary>
+    /// 放物線をLineRendererで描画するモノビヘイビア
+    /// </summary>
+    public class TrajectoryVisualizer : MonoBehaviour
+    {
+        [Header("描画設定")]
+        [SerializeField] private LineRenderer _lineRenderer;
+        [SerializeField] private int _segmentCount = 30;
+        [SerializeField] private float _timeStep = 0.1f;
+
+        private void Awake()
+        {
+            if (_lineRenderer == null)
+            {
+                _lineRenderer = GetComponent<LineRenderer>();
+            }
+        }
+
+        /// <summary>
+        /// 放物線を表示する
+        /// </summary>
+        public void ShowTrajectory(Vector3 startPos, Vector3 initialVelocity)
+        {
+            Vector3[] points = new Vector3[_segmentCount];
+            Vector3 currentPosition = startPos;
+            Vector3 currentVelocity = initialVelocity;
+
+            for (int i = 0; i < _segmentCount; i++)
+            {
+                points[i] = currentPosition;
+                currentVelocity += Physics.gravity * _timeStep;
+                Vector3 nextPosition = currentPosition + currentVelocity * _timeStep;
+
+                if (Physics.Linecast(currentPosition, nextPosition, out var hit))
+                {
+                    points[i + 1 >= _segmentCount ? i : i + 1] = hit.point;
+                    _lineRenderer.positionCount = i + 2;
+                    break;
+                }
+
+                currentPosition = nextPosition;
+            }
+
+            _lineRenderer.enabled = true;
+            _lineRenderer.SetPositions(points);
+        }
+
+        /// <summary>
+        /// 放物線描画を非表示にする
+        /// </summary>
+        public void Hide()
+        {
+            if (_lineRenderer != null)
+            {
+                _lineRenderer.enabled = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/InGame/Exhibit/CannonBall/Trajectory.cs.meta
+++ b/Assets/Scripts/InGame/Exhibit/CannonBall/Trajectory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c5571c07b1e87145aa2bcf2dcf63758

--- a/Assets/Scripts/InGame/Exhibit/EquipCannonBallEffect.cs
+++ b/Assets/Scripts/InGame/Exhibit/EquipCannonBallEffect.cs
@@ -11,12 +11,11 @@ namespace InGame.Exhibit
 
         public override void OnInteractStart(IInteractableContext context, InteractableBase target)
         {
-            target.IsInteractable = false;
+            target.LastInteractTime = int.MinValue;
             
             _canonBallModel.EquipToInteractor(context.Interactor);
             _canonBallModel.OnCannonBallHit += (() =>
             {
-                target.IsInteractable = true;
                 target.LastInteractTime = target.Runner.SimulationTime;
             });
         }

--- a/Assets/Scripts/InGame/Exhibit/EquipCannonBallEffect.cs
+++ b/Assets/Scripts/InGame/Exhibit/EquipCannonBallEffect.cs
@@ -11,10 +11,14 @@ namespace InGame.Exhibit
 
         public override void OnInteractStart(IInteractableContext context, InteractableBase target)
         {
-            target.LastInteractTime = int.MinValue; // リセット
+            target.IsInteractable = false;
             
             _canonBallModel.EquipToInteractor(context.Interactor);
-            _canonBallModel.OnCannonBallHit += (() => target.LastInteractTime = target.Runner.SimulationTime);
+            _canonBallModel.OnCannonBallHit += (() =>
+            {
+                target.IsInteractable = true;
+                target.LastInteractTime = target.Runner.SimulationTime;
+            });
         }
         
         public override CharacterInteractEffectBase Clone()

--- a/Assets/Scripts/InGame/Interact/CharacterInteractEffectBase.cs
+++ b/Assets/Scripts/InGame/Interact/CharacterInteractEffectBase.cs
@@ -8,7 +8,6 @@ namespace InGame.Interact
     public abstract class CharacterInteractEffectBase
     {
         protected CharacterInteractEffectBase () { }
-        
         [SerializeField]
         private CharacterType _characterType = CharacterType.All;
 

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -62,25 +62,25 @@ namespace InGame.Interact
             var type = context.CharacterType;
             if (IsInCooldown())
             {
-                Debug.LogError("[InteractableBase] クールダウン中のためインタラクトできません");
+                //Debug.LogError("[InteractableBase] クールダウン中のためインタラクトできません");
                 return false;
             }
 
             if (!Object.isActiveAndEnabled)
             {
-                Debug.LogError($"[{name}] インタラクト可能なオブジェクトが無効です");
+                //Debug.LogError($"[{name}] インタラクト可能なオブジェクトが無効です");
                 return false;
             }
             
             if (!ForceSetInteractable)
             {
-                Debug.LogError($"[{name}] インタラクト可能なオブジェクトが強制的に無効化されています");
+                //Debug.LogError($"[{name}] インタラクト可能なオブジェクトが強制的に無効化されています");
                 return false;
             }
 
             if (!OnValidateInteraction(context, type))
             {
-                Debug.LogError($"[{name}] インタラクト可能なオブジェクトが OnValidateInteraction により拒否されました");
+                //Debug.LogError($"[{name}] インタラクト可能なオブジェクトが OnValidateInteraction により拒否されました");
                 return false;
             }
 

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -21,7 +21,7 @@ namespace InGame.Interact
 
         [Networked] private float LastUsedCooldownTime { get; set; } = 0f;
         
-        [Networked] private bool IsInteractable { get; set; } = true;
+        [Networked] public bool IsInteractable { get; set; } = true;
 
         public SerializableDictionary<CharacterType, float> RequiredInteractTimeDictionary =>
             _requiredInteractTimeDictionary;

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -21,7 +21,10 @@ namespace InGame.Interact
 
         [Networked] private float LastUsedCooldownTime { get; set; } = 0f;
         
-        [Networked] public bool IsInteractable { get; set; } = true;
+        /// <summary>
+        /// 外部から強制的にインタラクト可能にするかどうかを設定するために使う
+        /// </summary>
+        [Networked] public bool ForceSetInteractable { get; set; } = true;
 
         public SerializableDictionary<CharacterType, float> RequiredInteractTimeDictionary =>
             _requiredInteractTimeDictionary;
@@ -57,7 +60,7 @@ namespace InGame.Interact
         public bool ValidateInteraction(IInteractableContext context)
         {
             var type = context.CharacterType;
-            if (IsInCooldown() || !Object.isActiveAndEnabled || !IsInteractable || !OnValidateInteraction(context, type))
+            if (IsInCooldown() || !Object.isActiveAndEnabled || !ForceSetInteractable || !OnValidateInteraction(context, type))
             {
                 return false;
             }

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -118,6 +118,7 @@ namespace InGame.Interact
 
         public bool IsInCooldown()
         {
+            if (LastUsedCooldownTime <= 0f) return false;
             var currentTime = Runner ? Runner.SimulationTime : Time.time;
             float timeSinceLast = currentTime - LastInteractTime;
             return timeSinceLast < LastUsedCooldownTime;

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -20,6 +20,8 @@ namespace InGame.Interact
         [Networked] public float LastInteractTime { get; set; } = -9999f;
 
         [Networked] private float LastUsedCooldownTime { get; set; } = 0f;
+        
+        [Networked] private bool IsInteractable { get; set; } = true;
 
         public SerializableDictionary<CharacterType, float> RequiredInteractTimeDictionary =>
             _requiredInteractTimeDictionary;
@@ -55,18 +57,12 @@ namespace InGame.Interact
         public bool ValidateInteraction(IInteractableContext context)
         {
             var type = context.CharacterType;
-            if (IsInCooldown())
+            if (IsInCooldown() || !Object.isActiveAndEnabled || !IsInteractable || !OnValidateInteraction(context, type))
             {
                 return false;
             }
 
-            if (!Object.isActiveAndEnabled)
-            {
-                Debug.Log($"[InteractableBase] オブジェクトが非アクティブです: {context.Interactor}");
-                return false;
-            }
-
-            return OnValidateInteraction(context, type);
+            return true;
         }
 
         /// <summary>

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -60,8 +60,27 @@ namespace InGame.Interact
         public bool ValidateInteraction(IInteractableContext context)
         {
             var type = context.CharacterType;
-            if (IsInCooldown() || !Object.isActiveAndEnabled || !ForceSetInteractable || !OnValidateInteraction(context, type))
+            if (IsInCooldown())
             {
+                Debug.LogError("[InteractableBase] クールダウン中のためインタラクトできません");
+                return false;
+            }
+
+            if (!Object.isActiveAndEnabled)
+            {
+                Debug.LogError($"[{name}] インタラクト可能なオブジェクトが無効です");
+                return false;
+            }
+            
+            if (!ForceSetInteractable)
+            {
+                Debug.LogError($"[{name}] インタラクト可能なオブジェクトが強制的に無効化されています");
+                return false;
+            }
+
+            if (!OnValidateInteraction(context, type))
+            {
+                Debug.LogError($"[{name}] インタラクト可能なオブジェクトが OnValidateInteraction により拒否されました");
                 return false;
             }
 

--- a/Assets/Scripts/InGame/Player/PlayerHealth.cs
+++ b/Assets/Scripts/InGame/Player/PlayerHealth.cs
@@ -34,6 +34,7 @@ namespace InGame.Player
             
             _cts = new CancellationTokenSource();
             _renderer = GetComponentInChildren<Renderer>();
+            _status = GetComponent<PlayerStatus>();
             _materialPropertyBlock = new MaterialPropertyBlock();
         }
 


### PR DESCRIPTION
#変更
・PlayerHealthでPlayerStatusの参照取るように
・大砲の弾でダメージが入らなかったのを修正
・MeleeHitBoxでBuffer上限に達した時のログを出すように
・インタラクトベースで強制的にインタラクト可能かを設定できるように
