### PR TITLE
[fix, update] 零戦のプロペラ音が止まらない問題を解決

### DIFF
--- a/Assets/Scripts/Common/CRI/CuePlayAtomExPlayer.cs
+++ b/Assets/Scripts/Common/CRI/CuePlayAtomExPlayer.cs
@@ -123,7 +123,7 @@ namespace CRISound
         {
             CriAtom.SetCategoryVolume("BGM", 1.0f);
             CriAtom.SetCategoryVolume("SE", 1.0f);
-            //CriAtom.SetCategoryVolume("Voice", 1.0f);
+            CriAtom.SetCategoryVolume("Voice", 1.0f);
         }
 
         private class SoundDic
@@ -186,8 +186,12 @@ namespace CRISound
 
             public bool IsPlayingCue(string cueName)
             {
-                return _atomExPlayer.GetStatus() == CriAtomExPlayer.Status.Playing &&
-                       _currentCueName == cueName;
+                if (_atomExPlayer.GetStatus() == CriAtomExPlayer.Status.Playing ||
+                    _atomExPlayer.GetStatus() == CriAtomExPlayer.Status.Prep && _currentCueName == cueName) // 準備状態も追加
+                {
+                    return true;
+                }
+                return false;
             }
 
             public virtual CriAtomExPlayback Play(string cueSheet, string cueName, float delay = 0.0f)
@@ -273,7 +277,12 @@ namespace CRISound
                 {
                     var status = _atomExPlayer3D.GetStatus();
                     var isNameMatch = _currentCueName == cueName;
-                    return status == CriAtomExPlayer.Status.Playing && isNameMatch;
+                    if (status == CriAtomExPlayer.Status.Playing ||
+                        status == CriAtomExPlayer.Status.Prep && isNameMatch) // 準備状態も追加
+                    {
+                        return true;
+                    }
+                    return false;
                 }
 
                 /// <summary>

--- a/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
+++ b/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
@@ -121,15 +121,12 @@ namespace InGame.Exhibit
                     if (_isEnd)
                     {
                         GetOff();
-                        AudioBroadcaster.RPC_StopSound("SE_ZeroFighter_Interact"); // 飛行中のループ音(サウンドデータの関係でInteractの音で判定)
                         return;
                     }
                     
                     if (CheckInteractEnd())
                     {
                         GetOff();
-                        AudioBroadcaster.RPC_StopSound("SE_ZeroFighter_Interact"); // 飛行中のループ音(サウンドデータの関係でInteractの音で判定)
-                        AudioBroadcaster.RPC_StopSound("SE_ZeroFighter_TakeoffGunFire"); // もしくは射撃音を止める
                         return;
                     }
                     
@@ -140,8 +137,6 @@ namespace InGame.Exhibit
                     if (timeSinceGetOn > 1f && input.Buttons.WasPressed(PreviousButtons, PlayerButtons.Interact))
                     {
                         GetOff();
-                        AudioBroadcaster.RPC_StopSound("SE_ZeroFighter_Interact"); // 飛行中のループ音(サウンドデータの関係でInteractの音で判定)
-                        AudioBroadcaster.RPC_StopSound("SE_ZeroFighter_TakeoffGunFire"); // もしくは射撃音を止める
                         return;
                     }
                     
@@ -303,7 +298,7 @@ namespace InGame.Exhibit
         {
             if (fireInput && _machineGunTimer <= 0)
             {
-                AudioBroadcaster.RPC_PlaySoundFromCode("SE_ZeroFighter_TakeoffGunFire", SoundTrackingType.Spot, Object);
+                AudioBroadcaster.RPC_PlaySoundFromCode(SoundCues.SE.ZeroFighter_TakeoffGunFire.Name, SoundTrackingType.Spot, Object); // 射撃音
                 Fire();
             }
             else if (_machineGunTimer > 0)
@@ -427,6 +422,8 @@ namespace InGame.Exhibit
                 formationManager.WarpFriendNearPlayer(_ownerPlayerManager.transform.position,
                     _ownerPlayerManager.transform.rotation);
             }
+            AudioBroadcaster.RequestStopSound(SoundCues.SE.ZeroFighter_Interact.Name);          // 飛行中のループ音(サウンドデータの関係でInteractの音で判定)
+            AudioBroadcaster.RequestStopSound(SoundCues.SE.ZeroFighter_TakeoffGunFire.Name);    // もしくは射撃音を止める
         }
 
         void OnChangeOwnerPlayerRef()


### PR DESCRIPTION
・GetOff関数に停止の処理をまとめた
・キュー名の直書きを修正
・CuePlayAtomExPlayerの再生中判定の条件を追加することで解決