### PR TITLE
[Fix]endifの位置修正

### DIFF
--- a/Assets/Scripts/InGame/Common/AnimationMontage/Editor/MontageRegistryBuilder.cs
+++ b/Assets/Scripts/InGame/Common/AnimationMontage/Editor/MontageRegistryBuilder.cs
@@ -9,7 +9,7 @@ using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
 using UnityEditor.AddressableAssets;
-#endif
+
 
 namespace InGame.Common.AnimationMontage
 {
@@ -167,3 +167,4 @@ namespace InGame.Common.AnimationMontage
         }
     }
 }
+#endif


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Move `#endif` preprocessor directive to correct location

- Fixes misplaced conditional compilation directive in editor code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["#endif at line 14"] -->|Move to end| B["#endif at line 170"]
  C["Editor-only code block"] -->|Properly enclosed| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MontageRegistryBuilder.cs</strong><dd><code>Relocate #endif to proper scope closure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Assets/Scripts/InGame/Common/AnimationMontage/Editor/MontageRegistryBuilder.cs

<ul><li>Removed <code>#endif</code> from line 14 (after using statements)<br> <li> Added <code>#endif</code> at end of file (line 170) to properly close the <code>#if </code><br><code>UNITY_EDITOR</code> block<br> <li> Ensures all editor-only code is correctly wrapped within conditional <br>compilation directive</ul>


</details>


  </td>
  <td><a href="https://github.com/LengaTakamura/September/pull/518/files#diff-f31bd5771ea024e458071d705224dc2bc2cd824bee52902ff6540e2ab0a10940">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

