### PR TITLE
[Fix]GetCancellationTokenOnDestroyでExption回避

### DIFF
--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -13,6 +13,7 @@ using InGame.Player;
 using CRISound;
 using September.InGame.UI;
 using WebSocketSharp;
+using System.Threading;
 
 namespace InGame.Interact
 {
@@ -167,10 +168,10 @@ namespace InGame.Interact
                 effectTransform.position + _cooldownEffectOffset, Quaternion.Euler(_cooldownEffectRotation));
 
             // クールダウン時間待機
-            await UniTask.Delay(TimeSpan.FromSeconds(cooldownTime), ignoreTimeScale: false);
+            await UniTask.Delay(TimeSpan.FromSeconds(cooldownTime), ignoreTimeScale: false,cancellationToken: this.GetCancellationTokenOnDestroy());
 
             // エフェクトを停止
-            effectSpawner.StopEffect(uniqueEffectId);
+            effectSpawner?.StopEffect(uniqueEffectId);
 
             // クールダウン回復音を全クライアントで再生
             Rpc_PlaySE(SoundCues.SE.Exhibit_Revive.Sheet, SoundCues.SE.Exhibit_Revive.Name, effectTransform.position);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add cancellation token to UniTask.Delay to prevent exception on destroy

- Add null-check operator to effectSpawner.StopEffect call

- Import System.Threading namespace for cancellation token support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PlayCooldownEffect method"] -->|Add cancellation token| B["UniTask.Delay"]
  A -->|Add null-check| C["effectSpawner.StopEffect"]
  D["System.Threading import"] -->|Enable| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InteractableBase.cs</strong><dd><code>Add cancellation token and null-check to cooldown effect</code>&nbsp; </dd></summary>
<hr>

Assets/Scripts/InGame/Interact/InteractableBase.cs

<ul><li>Added <code>System.Threading</code> namespace import for cancellation token support<br> <li> Modified <code>UniTask.Delay</code> call to include <code>cancellationToken: </code><br><code>this.GetCancellationTokenOnDestroy()</code> parameter to prevent exceptions <br>when object is destroyed during cooldown<br> <li> Added null-check operator (<code>?.</code>) to <code>effectSpawner.StopEffect</code> call for <br>safer null handling</ul>


</details>


  </td>
  <td><a href="https://github.com/LengaTakamura/September/pull/520/files#diff-d5c3335ff7408844ff096cc6c54679f80ba832b66ecf2f55ee0acf2439e8ab0c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

