### PR TITLE
[Fix]Nullチェック追加

### DIFF
--- a/Assets/Scripts/InGame/UI/AlphaUI/InGameStatusView.cs
+++ b/Assets/Scripts/InGame/UI/AlphaUI/InGameStatusView.cs
@@ -291,7 +291,7 @@ namespace September.InGame.UI
                     await ui.DOFade(1, 0.5f);
                     await UniTask.Delay(TimeSpan.FromSeconds(seconds));
                     await ui.DOFade(0, 0.5f);
-                    Destroy(ui.gameObject);
+                    Destroy(ui?.gameObject);
                     UpdateLayOutGroup();
                     break;
                 }
@@ -303,7 +303,7 @@ namespace September.InGame.UI
                     await ui.DOFade(1, 0.5f);
                     await UniTask.Delay(TimeSpan.FromSeconds(seconds - 1f));
                     await ui.DOFade(0, 0.5f);
-                    Destroy(ui.gameObject);
+                    Destroy(ui?.gameObject);
                     UpdateLayOutGroup();
                     break;
                 }
@@ -324,7 +324,7 @@ namespace September.InGame.UI
                     await ui.DOFade(1, 0.5f);
                     await UniTask.Delay(TimeSpan.FromSeconds(seconds - 1f));
                     await ui.DOFade(0, 0.5f);
-                    Destroy(ui.gameObject);
+                    Destroy(ui?.gameObject);
                     UpdateLayOutGroup();
                     break;
                 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add null-conditional operator to prevent null reference exceptions

- Apply null-safe access pattern to `ui?.gameObject` in three status UI destruction calls

- Protect against potential null values during async UI cleanup operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ShowStatusUpUI method"] -->|"Destroy UI after fade"| B["ui.gameObject"]
  B -->|"Add null-check"| C["ui?.gameObject"]
  C -->|"Safe destruction"| D["Prevent null exceptions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InGameStatusView.cs</strong><dd><code>Add null-conditional operators to UI destruction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Assets/Scripts/InGame/UI/AlphaUI/InGameStatusView.cs

<ul><li>Replace <code>ui.gameObject</code> with <code>ui?.gameObject</code> in three <code>Destroy()</code> calls <br>within <code>ShowStatusUpUI</code> method<br> <li> Applied to Heal, Tutankhamen, and BokeBoke status up type cases<br> <li> Prevents potential null reference exceptions during async UI cleanup <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/LengaTakamura/September/pull/523/files#diff-6560037907d89b34d8d9d5359988189710d97c8e9fa5f7cdf50a41e6b5f1460d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

