### PR TITLE
[Fix]呼び出し位置を修正

### DIFF
--- a/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
+++ b/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
@@ -394,7 +394,6 @@ namespace InGame.Exhibit
             var time = CooldownTimeDictionary.Dictionary.TryGetValue(CharacterType.All, out var all)
                 ? all
                 : CooldownTimeDictionary.Dictionary.GetValueOrDefault(chara, 0f);
-            PlayCooldownEffect(time).Forget();
             LastUsedCooldownTime = time;
             LastInteractTime = Runner.SimulationTime;
 
@@ -411,6 +410,7 @@ namespace InGame.Exhibit
 
             // 飛行機を初期位置・回転に戻す（ティラノと同じ仕組み）
             transform.SetPositionAndRotation(_initialPosition, _initialRotation);
+            PlayCooldownEffect(time).Forget();
             CurrentAccel = 0;
             _rb.linearVelocity = Vector3.zero;
             _rb.angularVelocity = Vector3.zero;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Move `PlayCooldownEffect()` call to after airplane reset

- Ensures cooldown effect plays after position/rotation restoration

- Fixes timing issue in `GetOff()` method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GetOff method"] --> B["Calculate cooldown time"]
  B --> C["Update player state"]
  C --> D["Reset airplane position/rotation"]
  D --> E["Play cooldown effect"]
  E --> F["Clear velocity"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PropAirplane.cs</strong><dd><code>Reorder cooldown effect call in GetOff</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Assets/Scripts/InGame/Exhibit/PropAirplane.cs

<ul><li>Relocated <code>PlayCooldownEffect(time).Forget()</code> call from line 397 to line <br>414<br> <li> Moved call to execute after airplane position and rotation reset<br> <li> Ensures visual effect plays after all state changes complete</ul>


</details>


  </td>
  <td><a href="https://github.com/LengaTakamura/September/pull/530/files#diff-9a590a1604d7bcb7651f749bfb427160410c1f73f558ed86c88dbde02489a27a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

