### PR TITLE
AnimationClipPlayer周りのリファクタリングと修正

### DIFF
--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -182,6 +182,47 @@ namespace InGame.Common
             return await PlayAsync(index);
         }
         
+        /// <summary> TopLayerでアニメーションを再生 </summary>
+        public void PlayOnTopLayer(AnimationClip clip)
+        {
+            if (!_slotOf.TryGetValue(LayerInfo.LayerType.TopLayer, out var slot))
+            {
+                Debug.LogWarning("[AnimationClipPlayer] TopLayer が設定されていません。_layerInfo の最後に追加してください。");
+                return;
+            }
+
+            // 解除要求
+            if (clip == null)
+            {
+                _layerMixer.SetInputWeight(slot, 0f);
+
+                if (_runtimeClips.TryGetValue(LayerInfo.LayerType.TopLayer, out var current) && current.IsValid())
+                {
+                    _layerMixer.DisconnectInput(slot);
+                    current.Destroy();
+                    _runtimeClips.Remove(LayerInfo.LayerType.TopLayer);
+                }
+
+                var li0 = _layerInfo[slot];
+                li0.Weight = 0f;
+                _layerInfo[slot] = li0;
+                return;
+            }
+
+            if (_runtimeClips.TryGetValue(LayerInfo.LayerType.TopLayer, out var prev) && prev.IsValid())
+            {
+                _layerMixer.DisconnectInput(slot);
+                prev.Destroy();
+                _runtimeClips.Remove(LayerInfo.LayerType.TopLayer);
+            }
+
+            Play(clip, LayerInfo.LayerType.TopLayer, 1f, additive: false);
+
+            var li = _layerInfo[slot];
+            li.Weight = 1f; // Update() で毎フレーム反映されるので内部Weightも更新
+            _layerInfo[slot] = li;
+        }
+        
         public void Play(AnimationClip clip, bool forcePlay = false)
         {
             if (!TryGetMontageIndex(clip, out int clipIndex))
@@ -673,46 +714,6 @@ namespace InGame.Common
                 await UniTask.Yield(PlayerLoopTiming.LastPostLateUpdate, token);
                 if (token.IsCancellationRequested) break;
             }
-        }
-        
-        public void SetTopPriorityClip(AnimationClip clip)
-        {
-            if (!_slotOf.TryGetValue(LayerInfo.LayerType.TopLayer, out var slot))
-            {
-                Debug.LogWarning("[AnimationClipPlayer] TopLayer が設定されていません。_layerInfo の最後に追加してください。");
-                return;
-            }
-
-            // 解除要求
-            if (clip == null)
-            {
-                _layerMixer.SetInputWeight(slot, 0f);
-
-                if (_runtimeClips.TryGetValue(LayerInfo.LayerType.TopLayer, out var current) && current.IsValid())
-                {
-                    _layerMixer.DisconnectInput(slot);
-                    current.Destroy();
-                    _runtimeClips.Remove(LayerInfo.LayerType.TopLayer);
-                }
-
-                var li0 = _layerInfo[slot];
-                li0.Weight = 0f;
-                _layerInfo[slot] = li0;
-                return;
-            }
-
-            if (_runtimeClips.TryGetValue(LayerInfo.LayerType.TopLayer, out var prev) && prev.IsValid())
-            {
-                _layerMixer.DisconnectInput(slot);
-                prev.Destroy();
-                _runtimeClips.Remove(LayerInfo.LayerType.TopLayer);
-            }
-
-            Play(clip, LayerInfo.LayerType.TopLayer, 1f, additive: false);
-
-            var li = _layerInfo[slot];
-            li.Weight = 1f; // Update() で毎フレーム反映されるので内部Weightも更新
-            _layerInfo[slot] = li;
         }
         
         /// <summary>

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -42,6 +42,8 @@ namespace InGame.Common
 
         public AnimationMixerPlayable BaseMixer => _baseMixer;
 
+        public bool IsValid => _graph.IsValid();
+
         #region Initialize
         public void Start()
         {

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -41,7 +41,6 @@ namespace InGame.Common
         private readonly Dictionary<LayerInfo.LayerType, AnimationClip> _clipOf = new();
 
         public AnimationMixerPlayable BaseMixer => _baseMixer;
-        public Animator Animator => _animator;
 
         #region Initialize
         public void Start()

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayerManager.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayerManager.cs
@@ -91,7 +91,7 @@ namespace InGame.Common
                 && !_animationClipPlayer.IsPlayingTargetClip(_jumpOver)
                 && !_animationClipPlayer.IsPlayingTargetClip(_fallDown))
             {
-                _animationClipPlayer.SetTopPriorityClip(_fallDown);
+                _animationClipPlayer.PlayOnTopLayer(_fallDown);
                 _animationClipPlayer.SetLayerWeight(LayerInfo.LayerType.TopLayer, 0f);
                 _animationClipPlayer.BlendLayerWeight(
                     LayerInfo.LayerType.TopLayer,
@@ -180,7 +180,7 @@ namespace InGame.Common
                 _jumpOverTokenSrc.Cancel();
                 _jumpOverTokenSrc.Dispose();
             }
-            _animationClipPlayer.SetTopPriorityClip(_jumpOver);
+            _animationClipPlayer.PlayOnTopLayer(_jumpOver);
             
             _jumpOverTokenSrc = new CancellationTokenSource();
             // ジャンプオーバークリップの長さだけ待機（速度変更を考慮しない場合は length をそのまま使用）
@@ -195,7 +195,7 @@ namespace InGame.Common
                     return;
                 }
             }
-            _animationClipPlayer.SetTopPriorityClip(null);
+            _animationClipPlayer.PlayOnTopLayer(null);
             if (!_playerMovement.IsGroundNet) SetFallAnim(false);
         }
         
@@ -204,7 +204,7 @@ namespace InGame.Common
         {
             _overrideCts?.Cancel();
             _hardOverride = false;
-            _animationClipPlayer.SetTopPriorityClip(null);
+            _animationClipPlayer.PlayOnTopLayer(null);
             _animationClipPlayer.SetLayerWeight(LayerInfo.LayerType.TopLayer, 0f);
             _overrideCts = null;
         }
@@ -222,7 +222,7 @@ namespace InGame.Common
                 // 気絶へフェードイン（TopLayer=1）
                 if (_faint != null)
                 {
-                    _animationClipPlayer.SetTopPriorityClip(_faint);
+                    _animationClipPlayer.PlayOnTopLayer(_faint);
                 }
                 _animationClipPlayer.SetLayerWeight(LayerInfo.LayerType.TopLayer, 0f);
 
@@ -241,7 +241,7 @@ namespace InGame.Common
                 // 起き上がり（任意）
                 if (_getUp != null)
                 {
-                    _animationClipPlayer.SetTopPriorityClip(_getUp);
+                    _animationClipPlayer.PlayOnTopLayer(_getUp);
                     if (_getUp.length > 0f)
                     {
                         await UniTask.Delay(TimeSpan.FromSeconds(_getUp.length), cancellationToken: cts.Token);
@@ -255,7 +255,7 @@ namespace InGame.Common
                     new LayerInfo.Blend { BlendTime = 0, BlendCurve = null }
                 );
 
-                _animationClipPlayer.SetTopPriorityClip(null);
+                _animationClipPlayer.PlayOnTopLayer(null);
                 _hardOverride = false;
                 _overrideCts = null;
             }
@@ -268,7 +268,7 @@ namespace InGame.Common
                 // 途中キャンセル時も確実に状態を畳む
                 if (_hardOverride && (cts.IsCancellationRequested))
                 {
-                    _animationClipPlayer.SetTopPriorityClip(null);
+                    _animationClipPlayer.PlayOnTopLayer(null);
                     _animationClipPlayer.SetLayerWeight(LayerInfo.LayerType.TopLayer, 0f);
                     _hardOverride = false;
                     if (ReferenceEquals(_overrideCts, cts)) _overrideCts = null;
@@ -292,7 +292,7 @@ namespace InGame.Common
             );
             if (_animationClipPlayer.IsPlayingTargetClip(_fallDown) &&
                 _animationClipPlayer.GetTargetLayerWeight(LayerInfo.LayerType.TopLayer) == 0)
-                _animationClipPlayer.SetTopPriorityClip(null);
+                _animationClipPlayer.PlayOnTopLayer(null);
         }
     }
 }

--- a/Assets/Scripts/InGame/Common/AnimationMontage/AnimationMontage.cs
+++ b/Assets/Scripts/InGame/Common/AnimationMontage/AnimationMontage.cs
@@ -13,8 +13,8 @@ namespace InGame.Common.AnimationMontage
         [SerializeField] private Avatar _overrideAvatar;
         [Header("PlaySettings")]
         [SerializeField, Min(0)] private float _playRate = 1f;
-        [SerializeField, Min(0)] private Blend _blendIn;
-        [SerializeField, Min(0)] private Blend _blendOut;
+        [SerializeField] private Blend _blendIn;
+        [SerializeField] private Blend _blendOut;
         [SerializeField] private bool _loop;
         [SerializeField, Tooltip("")] private AvatarMask _selectedMask;
         [Header("Sections")]

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerAsset.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerAsset.cs
@@ -1,10 +1,9 @@
 using System;
-using InGame.Common;
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
 
-namespace InGame.Player.Ult
+namespace InGame.Common.Timeline
 {
     [Serializable]
     public class AnimationClipPlayerAsset : PlayableAsset, ITimelineClipAsset, IPropertyPreview

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerAsset.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerAsset.cs
@@ -13,6 +13,8 @@ namespace InGame.Player.Ult
         
         public ClipCaps clipCaps => ClipCaps.None;
 
+        public override double duration => _playable.Clip == null ? base.duration : _playable.Clip.length;
+
         public override Playable CreatePlayable(PlayableGraph graph, GameObject owner)
         {
             var playable = ScriptPlayable<AnimationClipPlayerPlayable>.Create(graph, _playable);

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
@@ -1,8 +1,7 @@
-using InGame.Common;
 using UnityEngine;
 using UnityEngine.Playables;
 
-namespace InGame.Player.Ult
+namespace InGame.Common.Timeline
 {
     [System.Serializable]
     public class AnimationClipPlayerPlayable : PlayableBehaviour

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
@@ -55,13 +55,6 @@ namespace InGame.Player.Ult
 #endif
         }
 
-#if UNITY_EDITOR
-        public override void OnGraphStop(Playable playable)
-        {
-            if (!Application.isPlaying && _clipPlayer) _clipPlayer.SafeDestroy();
-        }
-#endif
-
         public override void OnBehaviourPause(Playable playable, FrameData info)
         {
             _info.Disconnect();

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
@@ -23,7 +23,10 @@ namespace InGame.Player.Ult
                 _clipPlayer = playerData as AnimationClipPlayer;
                 
 #if UNITY_EDITOR
-                if (!Application.isPlaying) _clipPlayer?.Start();
+                if (_clipPlayer && !_clipPlayer.IsValid)
+                {
+                    _clipPlayer.Start();
+                }
 #endif
             }
             
@@ -59,7 +62,6 @@ namespace InGame.Player.Ult
         {
             _info.Disconnect();
             _isPlayed = false;
-            
         }
     }
 }

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
@@ -22,7 +22,7 @@ namespace InGame.Common.Timeline
                 _clipPlayer = playerData as AnimationClipPlayer;
                 
 #if UNITY_EDITOR
-                if (_clipPlayer && !_clipPlayer.IsValid)
+                if (!Application.isPlaying && _clipPlayer && !_clipPlayer.IsValid)
                 {
                     _clipPlayer.Start();
                 }

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerTrack.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerTrack.cs
@@ -1,7 +1,6 @@
-using InGame.Common;
 using UnityEngine.Timeline;
 
-namespace InGame.Player.Ult
+namespace InGame.Common.Timeline
 {
     [TrackBindingType(typeof(AnimationClipPlayer))]
     [TrackClipType(typeof(AnimationClipPlayerAsset))]


### PR DESCRIPTION
- AnimationClipPlayerのメソッド SetTopPriorityClip を PlayOnTopLayer に改名
- Timeline側の処理で例外を発生させるものを修正
- Timeline側の名前空間をフォルダ階層に合わせて変更