### PR TITLE
操作説明UIの切り替え処理を修正

### DIFF
--- a/Assets/Prefabs/alphaUI/Canvas/MainCanvas.prefab
+++ b/Assets/Prefabs/alphaUI/Canvas/MainCanvas.prefab
@@ -216,6 +216,7 @@ GameObject:
   - component: {fileID: 4449145181785991315}
   - component: {fileID: 2932301518178117387}
   - component: {fileID: 2714732700162904962}
+  - component: {fileID: 6524674074025605059}
   m_Layer: 5
   m_Name: MainCanvas
   m_TagString: Untagged
@@ -238,6 +239,7 @@ RectTransform:
   - {fileID: 928295562626992006}
   - {fileID: 952631291772904391}
   - {fileID: 294724611427822424}
+  - {fileID: 5350015315830211674}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -325,6 +327,7 @@ MonoBehaviour:
   _timerData: {fileID: 11400000, guid: e2ca3e11eb6f46047839bebd36fd3c24, type: 2}
   _killLogItemText: {fileID: 6821879754397175384, guid: 6ff5edf30575f7d4296bd1e33d729efb, type: 3}
   _maxLogCount: 5
+  _controlsUIGenerator: {fileID: 6524674074025605059}
   _statusUpUI: {fileID: 0}
 --- !u!114 &2714732700162904962
 MonoBehaviour:
@@ -338,6 +341,134 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5a89ed21262e60745975ec89c572f4f0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6524674074025605059
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8375941926255285459}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eebee1cc1415c1542a4ba0142ccf5b3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _descriptionObject: {fileID: 1341192402949182476}
+  _iconPrefab: {fileID: 8509406873024271958, guid: 69355f2b7fb447b48a4b66c9236b3284, type: 3}
+  _descriptionDictionary:
+    keys: 00000000010000000200000003000000
+    values:
+    - {fileID: 11400000, guid: 51181377b98687c47a36c7651bf2254c, type: 2}
+    - {fileID: 11400000, guid: 51181377b98687c47a36c7651bf2254c, type: 2}
+    - {fileID: 11400000, guid: 51181377b98687c47a36c7651bf2254c, type: 2}
+    - {fileID: 11400000, guid: 51181377b98687c47a36c7651bf2254c, type: 2}
+--- !u!1001 &2241977469473301577
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 9133666892398446155}
+    m_Modifications:
+    - target: {fileID: 973276436727050309, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_Name
+      value: Description
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 68.162346
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -207
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 83
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+--- !u!1 &1341192402949182476 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 973276436727050309, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+  m_PrefabInstance: {fileID: 2241977469473301577}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5350015315830211674 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6134474665295814675, guid: 12fcc8e722228dc4f9ead33389a1105d, type: 3}
+  m_PrefabInstance: {fileID: 2241977469473301577}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8063436701030619473
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/CharacterDataContainer.asset
+++ b/Assets/ScriptableObjects/CharacterDataContainer.asset
@@ -81,3 +81,6 @@ MonoBehaviour:
     InteractVoice: VO_Koinuma_Interact_01
     UniqueActionVoice: VO_Koinuma_Grapple
     BGM: BGM_Koinuma_01
+  _controlDictionary:
+    keys: 01000000020000000300000004000000
+    values: 00000000000000000300000002000000

--- a/Assets/Scripts/Common/CharacterDataContainer.cs
+++ b/Assets/Scripts/Common/CharacterDataContainer.cs
@@ -35,6 +35,8 @@ namespace September.Common
             public string BGM;
         }
         [SerializeField, ArrayLength(DataCount)] CharacterData[] _characterData;
+        // キャラクターと操作説明を紐づけるための辞書
+        [SerializeField] SerializableDictionary<CharacterType, ControlDescriptionType> _controlDictionary;
 
         public static async UniTaskVoid LoadAssetAsync(string path)
         {
@@ -43,7 +45,23 @@ namespace September.Common
 
         public CharacterData GetCharacterData(CharacterType characterType)
         {
-            return _characterData.FirstOrDefault(data=>data.Type == characterType);
+            return _characterData.FirstOrDefault(data => data.Type == characterType);
+        }
+
+        /// <summary>
+        /// CharacterTypeに対応するControlDescriptionTypeを返す
+        /// </summary>
+        public ControlDescriptionType GetControlDescriptionType(CharacterType characterType)
+        {
+            if (_controlDictionary.Dictionary.TryGetValue(characterType, out var controlDescriptionType))
+            {
+                return controlDescriptionType;
+            }
+            else
+            {
+                Debug.LogError($"{characterType}に対応する操作説明が紐づけされていません");
+                return ControlDescriptionType.Player; // デフォルト値を返す
+            }
         }
 
         public CharacterData GetCharacterData(int index)

--- a/Assets/Scripts/InGame/Exhibit/MountableExhibitBase.cs
+++ b/Assets/Scripts/InGame/Exhibit/MountableExhibitBase.cs
@@ -174,19 +174,7 @@ namespace InGame.Exhibit
         public virtual void GetOff(PlayerRef playerRef)
         {
             PlayerDatabase.Instance.PlayerDataDic.TryGet(playerRef, out var playerData);
-            ControlDescriptionType type;
-            if(playerData.CharacterType == CharacterType.Sarutobi)
-            {
-                type = ControlDescriptionType.Sarutobi;
-            }
-            else if(playerData.CharacterType == CharacterType.Tanihira)
-            {
-                type = ControlDescriptionType.Tanihira;
-            }
-            else
-            {
-                type = ControlDescriptionType.Player;
-            }
+            ControlDescriptionType type = CharacterDataContainer.Instance.GetControlDescriptionType(playerData.CharacterType);
             RPC_ChangeDescriptionUI(playerRef, type);
             var chara = PlayerDatabase.Instance.PlayerDataDic[playerRef].CharacterType;
             var time = _interactable.CooldownTimeDictionary.Dictionary.TryGetValue(CharacterType.All, out var all)

--- a/Assets/Scripts/InGame/Exhibit/MountableExhibitBase.cs
+++ b/Assets/Scripts/InGame/Exhibit/MountableExhibitBase.cs
@@ -148,7 +148,7 @@ namespace InGame.Exhibit
             _ownerPlayerManager.RPC_SetColliderActive(false);
             _ownerPlayerManager.RPC_SetMeshActive(false);
             Object.AssignInputAuthority(playerRef);
-            RPC_ChangeDescriptionUI(playerRef,1);
+            RPC_ChangeDescriptionUI(playerRef, ControlDescriptionType.Exhibit);
             CameraController.Init(true);
             RPC_SetCameraPriority(playerRef,15);
             RPC_SetIsKinematic(false);
@@ -159,7 +159,7 @@ namespace InGame.Exhibit
         }
         
         [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
-        private void RPC_ChangeDescriptionUI(PlayerRef target, int mode)
+        private void RPC_ChangeDescriptionUI(PlayerRef target, ControlDescriptionType mode)
         {
             if (Runner.LocalPlayer == target)
             {
@@ -174,20 +174,20 @@ namespace InGame.Exhibit
         public virtual void GetOff(PlayerRef playerRef)
         {
             PlayerDatabase.Instance.PlayerDataDic.TryGet(playerRef, out var playerData);
-            int num;
+            ControlDescriptionType type;
             if(playerData.CharacterType == CharacterType.Sarutobi)
             {
-                num = 3;
+                type = ControlDescriptionType.Sarutobi;
             }
             else if(playerData.CharacterType == CharacterType.Tanihira)
             {
-                num = 4;
+                type = ControlDescriptionType.Tanihira;
             }
             else
             {
-                num = 2;
+                type = ControlDescriptionType.Player;
             }
-            RPC_ChangeDescriptionUI(playerRef, num);
+            RPC_ChangeDescriptionUI(playerRef, type);
             var chara = PlayerDatabase.Instance.PlayerDataDic[playerRef].CharacterType;
             var time = _interactable.CooldownTimeDictionary.Dictionary.TryGetValue(CharacterType.All, out var all)
                 ? all

--- a/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
+++ b/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
@@ -364,7 +364,7 @@ namespace InGame.Exhibit
             _ownerPlayerManager.RPC_SetUseGrav(false);
             _ownerPlayerManager.RPC_SetColliderActive(false);
             _ownerPlayerManager.RPC_SetMeshActive(false);
-            RPC_ChangeDescriptionUI(ownerPlayerRef,1);
+            RPC_ChangeDescriptionUI(ownerPlayerRef, ControlDescriptionType.Exhibit);
             RPC_SetIsKinematic(false);
             // 乗った時刻を記録
             GetOnTime = Runner.SimulationTime;
@@ -376,7 +376,7 @@ namespace InGame.Exhibit
         }
         
         [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
-        private void RPC_ChangeDescriptionUI(PlayerRef target, int mode)
+        private void RPC_ChangeDescriptionUI(PlayerRef target, ControlDescriptionType mode)
         {
             if (Runner.LocalPlayer == target)
             {
@@ -389,7 +389,7 @@ namespace InGame.Exhibit
             if (!Runner.IsServer || OwnerPlayerRef == PlayerRef.None) return;
             
             PlayerDatabase.Instance.PlayerDataDic.TryGet(OwnerPlayerRef, out var playerData);
-            RPC_ChangeDescriptionUI(OwnerPlayerRef, playerData.CharacterType == CharacterType.Sarutobi? 3 : 2);
+            RPC_ChangeDescriptionUI(OwnerPlayerRef, playerData.CharacterType == CharacterType.Sarutobi? ControlDescriptionType.Sarutobi : ControlDescriptionType.Player);
             var chara = PlayerDatabase.Instance.PlayerDataDic[OwnerPlayerRef].CharacterType;
             var time = CooldownTimeDictionary.Dictionary.TryGetValue(CharacterType.All, out var all)
                 ? all

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -425,20 +425,20 @@ namespace InGame.Interact
         public void EndInteract()
         {
             _activeEffectBase?.OnInteractEnd();
-            int num;
+            ControlDescriptionType type;
             if(_characterType == CharacterType.Tanihira)
             {
-                num = 4;
+                type = ControlDescriptionType.Tanihira;
             }
             else if(_characterType == CharacterType.Sarutobi)
             {
-                num = 3;
+                type = ControlDescriptionType.Sarutobi;
             }
             else
             {
-                num = 2;
+                type = ControlDescriptionType.Player;
             }
-            RPC_ChangeDescriptionUI(num);
+            RPC_ChangeDescriptionUI(type);
             _activeEffectBase = null;
             _characterType = CharacterType.None;
         }
@@ -448,7 +448,7 @@ namespace InGame.Interact
         /// </summary>
         /// <param name="mode">UIモード</param>
         [Rpc(RpcSources.StateAuthority, RpcTargets.InputAuthority)]
-        private void RPC_ChangeDescriptionUI(int mode)
+        private void RPC_ChangeDescriptionUI(ControlDescriptionType mode)
         {
             UIController.I.ChangeDescriptionUI(mode);
         }

--- a/Assets/Scripts/InGame/Interact/InteractableBase.cs
+++ b/Assets/Scripts/InGame/Interact/InteractableBase.cs
@@ -425,19 +425,7 @@ namespace InGame.Interact
         public void EndInteract()
         {
             _activeEffectBase?.OnInteractEnd();
-            ControlDescriptionType type;
-            if(_characterType == CharacterType.Tanihira)
-            {
-                type = ControlDescriptionType.Tanihira;
-            }
-            else if(_characterType == CharacterType.Sarutobi)
-            {
-                type = ControlDescriptionType.Sarutobi;
-            }
-            else
-            {
-                type = ControlDescriptionType.Player;
-            }
+            ControlDescriptionType type = CharacterDataContainer.Instance.GetControlDescriptionType(_characterType);
             RPC_ChangeDescriptionUI(type);
             _activeEffectBase = null;
             _characterType = CharacterType.None;

--- a/Assets/Scripts/InGame/StateMachine/State/PreparationState.cs
+++ b/Assets/Scripts/InGame/StateMachine/State/PreparationState.cs
@@ -42,15 +42,15 @@ namespace September.Common
                 var type = localData.CharacterType;
                 if (type == CharacterType.Tanihira)
                 {
-                    UIController.I.ChangeDescriptionUI(4);
+                    UIController.I.ChangeDescriptionUI(ControlDescriptionType.Tanihira);
                 }
                 else if (type == CharacterType.Sarutobi)
                 {
-                    UIController.I.ChangeDescriptionUI(3);
+                    UIController.I.ChangeDescriptionUI(ControlDescriptionType.Sarutobi);
                 }
                 else
                 {
-                    UIController.I.ChangeDescriptionUI(2);
+                    UIController.I.ChangeDescriptionUI(ControlDescriptionType.Player);
                 }
             }
 

--- a/Assets/Scripts/InGame/StateMachine/State/PreparationState.cs
+++ b/Assets/Scripts/InGame/StateMachine/State/PreparationState.cs
@@ -26,7 +26,6 @@ namespace September.Common
         [SerializeField] private CinemachineVirtualCamera _startCamera;
         [SerializeField] private Vector3 _cameraOffset;
         [SerializeField] private SetIcon _setIcon;
-        [SerializeField] private SerializableDictionary<CharacterType, ControlDescriptionType> _controlDescriptionDictionary;
         [SerializeField, Tooltip("開始時のPlayerの位置をランダム化する")] private bool _isRandomSpawn = false;
         private PlayerRef _firstOgrePlayer;
         private bool _hasRecordedPlayerSelection = false;
@@ -40,19 +39,9 @@ namespace September.Common
 
             if (PlayerDatabase.Instance.PlayerDataDic.TryGet(Context.Runner.LocalPlayer, out SessionPlayerData localData))
             {
-                var descriptionType = ControlDescriptionType.Player; // デフォルト
+                ControlDescriptionType type = CharacterDataContainer.Instance.GetControlDescriptionType(localData.CharacterType);
 
-                if (_controlDescriptionDictionary?.Dictionary != null &&
-                    _controlDescriptionDictionary.Dictionary.TryGetValue(localData.CharacterType, out var type))
-                {
-                    descriptionType = type;
-                }
-                else
-                {
-                    Debug.LogWarning($"CharacterType is not registered in Dictionary");
-                }
-
-                UIController.I.ChangeDescriptionUI(descriptionType);
+                UIController.I.ChangeDescriptionUI(type);
             }
 
             if (Context.Runner.IsServer)

--- a/Assets/Scripts/InGame/StateMachine/State/PreparationState.cs
+++ b/Assets/Scripts/InGame/StateMachine/State/PreparationState.cs
@@ -26,6 +26,7 @@ namespace September.Common
         [SerializeField] private CinemachineVirtualCamera _startCamera;
         [SerializeField] private Vector3 _cameraOffset;
         [SerializeField] private SetIcon _setIcon;
+        [SerializeField] private SerializableDictionary<CharacterType, ControlDescriptionType> _controlDescriptionDictionary;
         [SerializeField, Tooltip("開始時のPlayerの位置をランダム化する")] private bool _isRandomSpawn = false;
         private PlayerRef _firstOgrePlayer;
         private bool _hasRecordedPlayerSelection = false;
@@ -39,19 +40,19 @@ namespace September.Common
 
             if (PlayerDatabase.Instance.PlayerDataDic.TryGet(Context.Runner.LocalPlayer, out SessionPlayerData localData))
             {
-                var type = localData.CharacterType;
-                if (type == CharacterType.Tanihira)
+                var descriptionType = ControlDescriptionType.Player; // デフォルト
+
+                if (_controlDescriptionDictionary?.Dictionary != null &&
+                    _controlDescriptionDictionary.Dictionary.TryGetValue(localData.CharacterType, out var type))
                 {
-                    UIController.I.ChangeDescriptionUI(ControlDescriptionType.Tanihira);
-                }
-                else if (type == CharacterType.Sarutobi)
-                {
-                    UIController.I.ChangeDescriptionUI(ControlDescriptionType.Sarutobi);
+                    descriptionType = type;
                 }
                 else
                 {
-                    UIController.I.ChangeDescriptionUI(ControlDescriptionType.Player);
+                    Debug.LogWarning($"CharacterType is not registered in Dictionary");
                 }
+
+                UIController.I.ChangeDescriptionUI(descriptionType);
             }
 
             if (Context.Runner.IsServer)
@@ -60,7 +61,7 @@ namespace September.Common
                 Initialize().Forget();
             }
         }
-        
+
         private async UniTask Initialize()
         {
             await Runner.LoadScene("Field", LoadSceneMode.Additive);
@@ -118,7 +119,7 @@ namespace September.Common
                 }
                 PlayerDatabase.Instance.PlayerDataDic.Set(pair.Key, spd);
                 _setIcon.ShowIcon(pair.Key);
-                
+
                 index++;
             }
         }
@@ -133,7 +134,7 @@ namespace September.Common
         {
             OpeningSequence().Forget();
         }
-        
+
         private async UniTaskVoid OpeningSequence()
         {
             // 全クライアントで入力を無効化
@@ -156,15 +157,15 @@ namespace September.Common
             }
             //  準備フェーズ - 全クライアントで移動入力を有効化
             BGMManager.ReleseFlag();
-            
+
             // タイマー開始
             UIController.I.StartTimer(Context.Runner);
-            
+
             var countDownDuration = StaticServiceLocator.Instance.Get<InGameManager>().TimerData.PreStartTime;
             if (countDownDuration > 0)// 準備フェーズの時間が0秒以下の場合は下記の処理をスキップする。
             {
                 if (HasStateAuthority) RPC_ToggleInputs(true, false, true);
-                
+
                 // 準備フェーズを開始する
                 UIController.I.TimeOverlayMessage?.Invoke(TimeMessageType.PreparationStart).Forget();
                 // 準備フェーズが終了するまで待機
@@ -178,7 +179,7 @@ namespace September.Common
             {
                 await UIController.I.TimeOverlayMessage.Invoke(TimeMessageType.GameStart);
             }
-            
+
             //  ゲーム開始表示終了後に役職開示を行う
             SetOgreLamp();
 
@@ -247,7 +248,7 @@ namespace September.Common
             // スコアの更新処理
             PlayerDatabase.Instance.Server_RecalculateScore(killerRef);
         }
-        
+
         /// <summary>
         /// 鬼を抽選するメソッド
         /// </summary>
@@ -265,7 +266,7 @@ namespace September.Common
             _firstOgrePlayer = ogreKey;
             PlayerDatabase.Instance.Server_AddOgreCount(ogreKey);
         }
-        
+
         /// <summary>
         /// 各Playerの気絶時に呼ばれるメソッド
         /// </summary>
@@ -293,13 +294,13 @@ namespace September.Common
             UpdateStunData(data.ExecutorRef, killerData, data.TargetRef);
             Rpc_ShowKillLog(data.ExecutorRef, data.TargetRef);
         }
-        
+
         private void HideCursor()
         {
             Cursor.visible = false;
             Cursor.lockState = CursorLockMode.Locked;
         }
-        
+
         private void SetOgreLamp()
         {
             if (PlayerDatabase.Instance.PlayerDataDic[Context.Runner.LocalPlayer].IsOgre)

--- a/Assets/Scripts/InGame/UI/AlphaUI/InGameStatusView.cs
+++ b/Assets/Scripts/InGame/UI/AlphaUI/InGameStatusView.cs
@@ -43,7 +43,7 @@ namespace September.InGame.UI
         private GameObject _ogreUiInstance;
         private ChangeTagOverlayMessage _changeTagOverlayMessage;
         private TimeOverlayMessage _timeOverlayMessage;
-        private GameObject[] _descriptionIcon;
+        private ControlDescription[] _descriptionIcon;
         private InteractUi _interactUI;
         private UniTask _ogreMessageTask;
         private TextMeshProUGUI _scoreText;
@@ -154,40 +154,9 @@ namespace September.InGame.UI
         //     await resultAnim.Play(resultUI);
         // }
 
-        private void ChangeExhibitDescriptionUI(int value)
+        private void ChangeExhibitDescriptionUI(ControlDescriptionType description)
         {
-            if (value == 1)
-            {
-                // 展示物操作方法をアクティブ
-                _descriptionIcon[0].SetActive(false);
-                _descriptionIcon[1].SetActive(true);
-                _descriptionIcon[2].SetActive(false);
-                _descriptionIcon[3].SetActive(false);
-            }
-            else if(value == 2)
-            {
-                // Player操作をアクティブ
-                _descriptionIcon[0].SetActive(true);
-                _descriptionIcon[1].SetActive(false);
-                _descriptionIcon[2].SetActive(false);
-                _descriptionIcon[3].SetActive(false);
-            }
-            else if (value == 3)
-            {
-                // サルトビ
-                _descriptionIcon[0].SetActive(false);
-                _descriptionIcon[1].SetActive(false);
-                _descriptionIcon[2].SetActive(true);
-                _descriptionIcon[3].SetActive(false);
-            }
-            else if(value == 4)
-            {
-                //タニヒラ
-                _descriptionIcon[0].SetActive(false);
-                _descriptionIcon[1].SetActive(false);
-                _descriptionIcon[2].SetActive(false);
-                _descriptionIcon[3].SetActive(true);
-            }
+            
         }
 
         private void ChangeStamina(float value)

--- a/Assets/Scripts/InGame/UI/AlphaUI/InGameStatusView.cs
+++ b/Assets/Scripts/InGame/UI/AlphaUI/InGameStatusView.cs
@@ -30,7 +30,9 @@ namespace September.InGame.UI
         [Header("キルログ")]
         [SerializeField] private GameObject  _killLogItemText;
         [SerializeField] private int _maxLogCount = 5;
-        
+
+        [SerializeField] private ControlsUIGenerator _controlsUIGenerator;
+
         [SerializeField] private CanvasGroup _statusUpUI;
         private VerticalLayoutGroup _statusUpLayout;
 
@@ -43,7 +45,6 @@ namespace September.InGame.UI
         private GameObject _ogreUiInstance;
         private ChangeTagOverlayMessage _changeTagOverlayMessage;
         private TimeOverlayMessage _timeOverlayMessage;
-        private ControlDescription[] _descriptionIcon;
         private InteractUi _interactUI;
         private UniTask _ogreMessageTask;
         private TextMeshProUGUI _scoreText;
@@ -99,7 +100,6 @@ namespace September.InGame.UI
             _ogreUiInstance = _uiRoot.OgreUI;
             _changeTagOverlayMessage = _uiRoot.ChangeTagOverlayMessage;
             _timeOverlayMessage = _uiRoot.TimeOverlayMessage;
-            _descriptionIcon =  _uiRoot.DescriptionIcon;
             _hpBarSlider = _uiRoot.HpBar;
             _scoreText =  _uiRoot.ScoreText;
             _staminaBarSlider = _uiRoot.StaminaBar;
@@ -154,9 +154,9 @@ namespace September.InGame.UI
         //     await resultAnim.Play(resultUI);
         // }
 
-        private void ChangeExhibitDescriptionUI(ControlDescriptionType description)
+        private void ChangeExhibitDescriptionUI(ControlDescriptionType type)
         {
-            
+            _controlsUIGenerator.GenerateDescription(type);
         }
 
         private void ChangeStamina(float value)

--- a/Assets/Scripts/InGame/UI/AlphaUI/InGameUIRootRefs.cs
+++ b/Assets/Scripts/InGame/UI/AlphaUI/InGameUIRootRefs.cs
@@ -29,6 +29,6 @@ namespace September.InGame.UI
         [Header("Timer")] 
         public TextMeshProUGUI TimerText;
         [Header("Description"),Label("1番目にPlayerの操作UI,2番目に展示物の操作UI")]
-        public GameObject[] DescriptionIcon;
+        public ControlDescription[] DescriptionIcon;
     }
 }

--- a/Assets/Scripts/InGame/UI/AlphaUI/UIController.cs
+++ b/Assets/Scripts/InGame/UI/AlphaUI/UIController.cs
@@ -14,7 +14,7 @@ namespace September.InGame.UI
         #region イベント
         
         private readonly Subject<bool> _onClickOptionButton = new();
-        private readonly Subject<int> _onChangeDescriptionUI = new();
+        private readonly Subject<ControlDescriptionType> _onChangeDescriptionUI = new();
         private readonly ReactiveProperty<int> _onChangeSliderValue = new();
         private readonly Subject<NetworkRunner> _onStartTimer = new();
         private readonly Subject<string> _onShowLog = new();
@@ -39,7 +39,7 @@ namespace September.InGame.UI
         public IObservable<bool> OnShowOgreUI => _onShowOgreUI;
         public IObservable<int> ChangeTagNoticeObserver => _changeTagNoticeObserver;
         public IReadOnlyReactiveProperty<float> OnChangeStaminaValue => _onChangeStaminaValue;
-        public IObservable<int> OnChangeDescriptionUI => _onChangeDescriptionUI;
+        public IObservable<ControlDescriptionType> OnChangeDescriptionUI => _onChangeDescriptionUI;
         public IObservable<Unit> OnGameStart => _onGameStart;
         public IObservable<Unit> OnGameEnd => _onGameEnd;
         public IObservable<(bool, GameObject)> IsInteracting => _isInteracting;
@@ -72,9 +72,9 @@ namespace September.InGame.UI
             _onShowLog.OnNext(text);
         }
 
-        public void ChangeDescriptionUI(int value)
+        public void ChangeDescriptionUI(ControlDescriptionType type)
         {
-            _onChangeDescriptionUI.OnNext(value);
+            _onChangeDescriptionUI.OnNext(type);
         }
         
         public void StartTimer(NetworkRunner runner)

--- a/Assets/Scripts/InGame/UI/ControlDescription.cs
+++ b/Assets/Scripts/InGame/UI/ControlDescription.cs
@@ -8,7 +8,16 @@ using System.Collections.Generic;
 [CreateAssetMenu(fileName = "Description", menuName = "Scriptable Objects/ControlDescriptionUI")]
 public class ControlDescription : ScriptableObject
 {
+    public ControlDescriptionType Type;
     public List<DescribedAction> Actions;
+}
+
+public enum ControlDescriptionType
+{
+    Player,
+    Exhibit,
+    Sarutobi,
+    Tanihira
 }
 
 /// <summary>

--- a/Assets/Scripts/InGame/UI/ControlDescription.cs
+++ b/Assets/Scripts/InGame/UI/ControlDescription.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 [CreateAssetMenu(fileName = "Description", menuName = "Scriptable Objects/ControlDescriptionUI")]
 public class ControlDescription : ScriptableObject
 {
-    public ControlDescriptionType Type;
     public List<DescribedAction> Actions;
 }
 

--- a/Assets/Scripts/InGame/UI/ControlsUIGenerator.cs
+++ b/Assets/Scripts/InGame/UI/ControlsUIGenerator.cs
@@ -7,20 +7,21 @@ public class ControlsUIGenerator : MonoBehaviour
     // 操作説明を生成した際にそのオブジェクトの親になるオブジェクト
     // VerticalLayoutGroup,ContentSizeFitterなどのレイアウトコンポーネントがアタッチされていることを想定
     [SerializeField] private GameObject _descriptionObject;
-    [SerializeField] private ControlDescription _descriptionData;
     [SerializeField] private GameObject _iconPrefab;
+
+    [SerializeField] 
+    private SerializableDictionary<ControlDescriptionType, ControlDescription> _descriptionDictionary;
 
     private void Start()
     {
-        GenerateDescription(_descriptionData);
+        // GenerateDescription(_descriptionData);
     }
 
     /// <summary>
     /// ControlDescriptionの内容をもとに操作説明UIを生成する
     /// </summary>
-    public void GenerateDescription(ControlDescription description)
+    public void GenerateDescription(ControlDescriptionType descriptionType)
     {
-       
         if (_descriptionObject == null)
         {
             Debug.LogError("DescriptionObject is not assigned");
@@ -28,6 +29,8 @@ public class ControlsUIGenerator : MonoBehaviour
         }
 
         ClearChildren();
+
+        ControlDescription description = _descriptionDictionary.Dictionary[descriptionType];
 
         foreach (var action in description.Actions)
         {

--- a/Assets/Scripts/InGame/UI/ControlsUIGenerator.cs
+++ b/Assets/Scripts/InGame/UI/ControlsUIGenerator.cs
@@ -12,11 +12,6 @@ public class ControlsUIGenerator : MonoBehaviour
     [SerializeField] 
     private SerializableDictionary<ControlDescriptionType, ControlDescription> _descriptionDictionary;
 
-    private void Start()
-    {
-        // GenerateDescription(_descriptionData);
-    }
-
     /// <summary>
     /// ControlDescriptionの内容をもとに操作説明UIを生成する
     /// </summary>


### PR DESCRIPTION
・切り替えの判断をintで行っていたのをenumに変更した
・enumに対応した説明のデータを辞書で管理し、切り替えが行われた際に対応するデータを基に説明を生成する