### PR TITLE
タニヒラペンギンの修正

### DIFF
--- a/Assets/Prefabs/Ability/BossPenguin.prefab
+++ b/Assets/Prefabs/Ability/BossPenguin.prefab
@@ -643,6 +643,7 @@ MonoBehaviour:
   _attackEffectPos: {fileID: 1881937996601921261}
   _runEffectObject: {fileID: 6303266605181236520}
   _maxRunBlendTreeCount: 5
+  _regulationAttackAmount: 20
   IsAttack: 0
   IsWarp: 0
 --- !u!195 &-3575381120417351687

--- a/Assets/Prefabs/Ability/ChildPenguin.prefab
+++ b/Assets/Prefabs/Ability/ChildPenguin.prefab
@@ -384,6 +384,7 @@ MonoBehaviour:
   _attackEffectPos: {fileID: 3005691076101400526}
   _runEffectObject: {fileID: 8043574276842796753}
   _maxRunBlendTreeCount: 5
+  _regulationAttackAmount: 20
   IsAttack: 0
   IsWarp: 0
 --- !u!65 &4605572418024795219

--- a/Assets/Prefabs/Tanihira Variant.prefab
+++ b/Assets/Prefabs/Tanihira Variant.prefab
@@ -6383,7 +6383,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _detectionCenter: {fileID: 3862667250155884466}
-  _detectionRadius: 15
+  _detectionRadius: 5
   _detectionMask:
     serializedVersion: 2
     m_Bits: 64
@@ -6392,8 +6392,8 @@ MonoBehaviour:
     m_Bits: 191
   _friendStateChanger: {fileID: 2957292007609013862}
   _formationManager: {fileID: 913702230075351532}
+  _friendOrder: {fileID: 6708881702509990833}
   _isWaiting: 0
-  _tanihiraCursor: {fileID: 2833980278294200028}
   _tyrannoInteractables: []
   _isSerching: 1
 --- !u!114 &2957292007609013862
@@ -6433,7 +6433,6 @@ MonoBehaviour:
   _changeOffsetDuration: 0.2
   _cursorOffsetY: 0.5
   _moveTargetPrefab: {fileID: 6185508062456583009, guid: 87568c7b0a84a9346bbd984a335f9170, type: 3}
-  IsInstruction: 0
 --- !u!114 &6708881702509990833
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Tanihira Variant.prefab
+++ b/Assets/Prefabs/Tanihira Variant.prefab
@@ -6393,6 +6393,7 @@ MonoBehaviour:
   _friendStateChanger: {fileID: 2957292007609013862}
   _formationManager: {fileID: 913702230075351532}
   _isWaiting: 0
+  _tanihiraCursor: {fileID: 2833980278294200028}
   _tyrannoInteractables: []
   _isSerching: 1
 --- !u!114 &2957292007609013862
@@ -6432,6 +6433,7 @@ MonoBehaviour:
   _changeOffsetDuration: 0.2
   _cursorOffsetY: 0.5
   _moveTargetPrefab: {fileID: 6185508062456583009, guid: 87568c7b0a84a9346bbd984a335f9170, type: 3}
+  IsInstruction: 0
 --- !u!114 &6708881702509990833
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/InGame/Player/Tanihira/FormationManager.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FormationManager.cs
@@ -232,6 +232,18 @@ namespace Ingame.Tanihira
             }
         }
         
+        /// <summary>
+        /// 隊列のペンギンに攻撃指示状態を設定する
+        /// </summary>
+        /// <param name="isOrdered">攻撃指示を行う場合はtrue</param>
+        public void SetAllAttackOrdered(bool isOrdered)
+        {
+            foreach (var friend in CurrentFriendsList)
+            {
+                friend.SetAttackOrdered(isOrdered);
+            }
+        }
+        
 #if UNITY_EDITOR       
         private void OnDrawGizmos()
         {

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using CRISound;
 using Fusion;
 using InGame.Health;
 using September.Common;
@@ -44,8 +42,10 @@ namespace Ingame.Tanihira
         [SerializeField] private float _maxRunBlendTreeCount = 5.0f;
         [Networked] private NetworkBool HasMask { get; set; }
         [Networked] private NetworkBool HasRunEffect { get; set; }
-        [Header("攻撃可能フラグ")]
-        [SerializeField] private bool _isAttackPossible = true;
+        [Header("攻撃指示")]
+        [SerializeField] private bool _isAttackOrdered;
+        [Header("攻撃可能")]
+        [SerializeField] private bool _isCanAttack = true;
         [Header("規定の攻撃量（超えたら指示があるまで攻撃はしない）")] 
         [SerializeField] private int _regulationAttackAmount;
         
@@ -87,8 +87,9 @@ namespace Ingame.Tanihira
         /// true：可能
         /// false：不可能
         /// </summary>
-        public bool IsAttackPossible => _isAttackPossible;
-        
+        public bool IsAttackPossible => _isCanAttack && _isAttackOrdered;
+        public bool IsAttackOrdered => _isAttackOrdered;
+
         public override void Spawned()
         {
             _currentStatus = _friendStatus.Clone();
@@ -256,7 +257,8 @@ namespace Ingame.Tanihira
             if (_currentAttackAmount >= _regulationAttackAmount)
             {
                 // 規定量を超えたら攻撃を辞め、プレイヤーの元に帰還する
-                _isAttackPossible = false;
+                _isCanAttack = false;
+                _isAttackOrdered = false;
                 SetDestination(OwnerPlayer.transform);
                 ChangeState(FriendState.Move);
             }
@@ -374,7 +376,17 @@ namespace Ingame.Tanihira
         public void ResetAttackAmount()
         {
             _currentAttackAmount = 0;
-            _isAttackPossible = true;
+            _isCanAttack = true;
+            SetAttackOrdered(false);
+        }
+
+        /// <summary>
+        /// 攻撃指示状態を設定
+        /// </summary>
+        /// <param name="isOrdered">攻撃指示を行う場合はtrue</param>
+        public void SetAttackOrdered(bool isOrdered)
+        {
+            _isAttackOrdered = isOrdered;
         }
     }
 }

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
@@ -61,7 +61,7 @@ namespace Ingame.Tanihira
         /// <summary>
         /// 現在の攻撃量
         /// </summary>
-        public int _currentAttackAmount;
+        private int _currentAttackAmount;
 
         private static int _spawnCount;
         public bool IsAttack;
@@ -88,14 +88,6 @@ namespace Ingame.Tanihira
         /// false：不可能
         /// </summary>
         public bool IsAttackPossible => _isAttackPossible;
-        /// <summary>
-        /// 規定の攻撃量
-        /// </summary>
-        public int RegulationAA => _regulationAttackAmount;
-        /// <summary>
-        /// 現在の攻撃量
-        /// </summary>
-        public int CurrentAA => _currentAttackAmount;
         
         public override void Spawned()
         {
@@ -263,7 +255,10 @@ namespace Ingame.Tanihira
             _currentAttackAmount += _currentStatus.AttackPower;
             if (_currentAttackAmount >= _regulationAttackAmount)
             {
+                // 規定量を超えたら攻撃を辞め、プレイヤーの元に帰還する
                 _isAttackPossible = false;
+                SetDestination(OwnerPlayer.transform);
+                ChangeState(FriendState.Move);
             }
         }
         

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
@@ -43,9 +43,9 @@ namespace Ingame.Tanihira
         [Networked] private NetworkBool HasMask { get; set; }
         [Networked] private NetworkBool HasRunEffect { get; set; }
         [Header("攻撃指示")]
-        [SerializeField] private bool _isAttackOrdered;
+        [Networked] public NetworkBool IsAttackOrdered { get;  private set; }
         [Header("攻撃可能")]
-        [SerializeField] private bool _isCanAttack = true;
+        [Networked] public NetworkBool IsCanAttack { get; private set; }
         [Header("規定の攻撃量（超えたら指示があるまで攻撃はしない）")] 
         [SerializeField] private int _regulationAttackAmount;
         
@@ -87,8 +87,7 @@ namespace Ingame.Tanihira
         /// true：可能
         /// false：不可能
         /// </summary>
-        public bool IsAttackPossible => _isCanAttack && _isAttackOrdered;
-        public bool IsAttackOrdered => _isAttackOrdered;
+        public bool IsAttackPossible => IsCanAttack && IsAttackOrdered;
 
         public override void Spawned()
         {
@@ -251,16 +250,29 @@ namespace Ingame.Tanihira
             damageable.TakeHit(ref hitData);
             //エフェクトを出す
             PlayEffect();
-
+            
             // 現在の攻撃量に攻撃力分増加させる
             _currentAttackAmount += _currentStatus.AttackPower;
             if (_currentAttackAmount >= _regulationAttackAmount)
             {
                 // 規定量を超えたら攻撃を辞め、プレイヤーの元に帰還する
-                _isCanAttack = false;
-                _isAttackOrdered = false;
+                IsCanAttack = false;
+                IsAttackOrdered = false;
                 SetDestination(OwnerPlayer.transform);
                 ChangeState(FriendState.Move);
+                if (OwnerPlayer.TryGetComponent<FriendPlayerDetector>(out var detector))
+                {
+                    // 全ペンギンの攻撃を止めにする
+                    detector.ChangeDetectionCenter(OwnerPlayer.transform, true);
+                    if (OwnerPlayer.TryGetComponent<FormationManager>(out var formationManager))
+                    {
+                        foreach (var fr in formationManager.CurrentFriendsList)
+                        {
+                            fr.IsCanAttack = false;
+                            fr.IsAttackOrdered = false;
+                        }
+                    }
+                }
             }
         }
         
@@ -376,7 +388,7 @@ namespace Ingame.Tanihira
         public void ResetAttackAmount()
         {
             _currentAttackAmount = 0;
-            _isCanAttack = true;
+            IsCanAttack = true;
             SetAttackOrdered(false);
         }
 
@@ -386,7 +398,7 @@ namespace Ingame.Tanihira
         /// <param name="isOrdered">攻撃指示を行う場合はtrue</param>
         public void SetAttackOrdered(bool isOrdered)
         {
-            _isAttackOrdered = isOrdered;
+            IsAttackOrdered = isOrdered;
         }
     }
 }

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
@@ -44,6 +44,10 @@ namespace Ingame.Tanihira
         [SerializeField] private float _maxRunBlendTreeCount = 5.0f;
         [Networked] private NetworkBool HasMask { get; set; }
         [Networked] private NetworkBool HasRunEffect { get; set; }
+        [Header("攻撃可能フラグ")]
+        [SerializeField] private bool _isAttackPossible = true;
+        [Header("規定の攻撃量（超えたら指示があるまで攻撃はしない）")] 
+        [SerializeField] private int _regulationAttackAmount;
         
         protected NavMeshAgent _agent;
         protected NetworkRunner _networkRunner;
@@ -54,6 +58,10 @@ namespace Ingame.Tanihira
         protected FriendStatus _currentStatus;
         protected EffectSpawner _effectSpawner;
         protected bool _isEnd;
+        /// <summary>
+        /// 現在の攻撃量
+        /// </summary>
+        public int _currentAttackAmount;
 
         private static int _spawnCount;
         public bool IsAttack;
@@ -73,6 +81,21 @@ namespace Ingame.Tanihira
         public NetworkObject OwnerPlayer => _ownerPlayer;
         public GameObject Tutankhamen => _tutankhamen;
         public bool IsWarp;
+
+        /// <summary>
+        /// 攻撃可能な状態か
+        /// true：可能
+        /// false：不可能
+        /// </summary>
+        public bool IsAttackPossible => _isAttackPossible;
+        /// <summary>
+        /// 規定の攻撃量
+        /// </summary>
+        public int RegulationAA => _regulationAttackAmount;
+        /// <summary>
+        /// 現在の攻撃量
+        /// </summary>
+        public int CurrentAA => _currentAttackAmount;
         
         public override void Spawned()
         {
@@ -235,6 +258,13 @@ namespace Ingame.Tanihira
             damageable.TakeHit(ref hitData);
             //エフェクトを出す
             PlayEffect();
+
+            // 現在の攻撃量に攻撃力分増加させる
+            _currentAttackAmount += _currentStatus.AttackPower;
+            if (_currentAttackAmount >= _regulationAttackAmount)
+            {
+                _isAttackPossible = false;
+            }
         }
         
         private void PlayEffect()
@@ -341,6 +371,15 @@ namespace Ingame.Tanihira
                 default:
                     break;
             }
+        }
+
+        /// <summary>
+        /// 現在の攻撃量、フラグをリセットする
+        /// </summary>
+        public void ResetAttackAmount()
+        {
+            _currentAttackAmount = 0;
+            _isAttackPossible = true;
         }
     }
 }

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendOrder.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendOrder.cs
@@ -26,7 +26,7 @@ namespace Ingame.Tanihira
             
             if (input.Buttons.WasPressed(PreviousButtons, PlayerButtons.Ability1))
             {
-                _cursor.IsInstruction = false;
+                _formationManager.SetAllAttackOrdered(false);
                 OrderReturnFriend();
             }
             

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendOrder.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendOrder.cs
@@ -26,6 +26,7 @@ namespace Ingame.Tanihira
             
             if (input.Buttons.WasPressed(PreviousButtons, PlayerButtons.Ability1))
             {
+                _cursor.IsInstruction = false;
                 OrderReturnFriend();
             }
             
@@ -66,6 +67,19 @@ namespace Ingame.Tanihira
         public void AfterTick()
         {
             PreviousButtons = GetInput<PlayerInput>().GetValueOrDefault().Buttons;
+        }
+
+        /// <summary>
+        /// ペンギンの現在の攻撃量を初期化する
+        /// ・再度指示が行われたときに呼び出す
+        /// </summary>
+        public void AllResetAttackAmount()
+        {
+            // 全てのペンギンに対して現在の攻撃量を初期化する
+            foreach (var friend in _formationManager.FriendsList)
+            {
+                friend.ResetAttackAmount();
+            }
         }
     }
 }

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendPlayerDetector.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendPlayerDetector.cs
@@ -143,10 +143,19 @@ namespace Ingame.Tanihira
             //ペンギンに攻撃指示を飛ばす
             if (_currentTarget)
             {
-                // 指示を行っていない場合、攻撃処理を行わない
-                if (!_tanihiraCursor.IsInstruction)
+                bool flag = false;
+                // 攻撃指示を受けているかを判定する
+                foreach (var friend in _formationManager.CurrentFriendsList)
                 {
-                    Debug.LogWarning("指示を行っていないので、攻撃処理は行わない");
+                    if (friend.IsAttackOrdered)
+                    {
+                        flag = true;
+                        break;
+                    }
+                }
+
+                if (!flag)
+                {
                     _friendStateChanger.SetMoveState();
                     return;
                 }

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendPlayerDetector.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendPlayerDetector.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Fusion;
-using InGame.Player;
 using September.Common;
 using September.InGame.Common;
 using UnityEngine;
@@ -17,6 +16,8 @@ namespace Ingame.Tanihira
         [SerializeField] private FriendStateChanger _friendStateChanger;
         [SerializeField] private FormationManager _formationManager;
         [SerializeField] private bool _isWaiting;
+        [Header("TanihiraCursor")]
+        [SerializeField] private TanihiraCursor _tanihiraCursor;
         
         private Transform _currentTarget;
         private InGameManager _inGameManager;
@@ -105,7 +106,7 @@ namespace Ingame.Tanihira
                 .Distinct()
                 .OrderBy(root => (root.position - _detectionCenter.position).sqrMagnitude)
                 .ToList();
-
+            
             foreach (Transform player in uniqueRoots)
             {
                 //自身は除く
@@ -142,6 +143,13 @@ namespace Ingame.Tanihira
             //ペンギンに攻撃指示を飛ばす
             if (_currentTarget)
             {
+                // 指示を行っていない場合、攻撃処理を行わない
+                if (!_tanihiraCursor.IsInstruction)
+                {
+                    Debug.LogWarning("指示を行っていないので、攻撃処理は行わない");
+                    _friendStateChanger.SetMoveState();
+                    return;
+                }
                 _friendStateChanger.SetChaseState(_currentTarget);
             }
             else

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendPlayerDetector.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendPlayerDetector.cs
@@ -15,9 +15,8 @@ namespace Ingame.Tanihira
         [SerializeField] private LayerMask _obstacleMask;
         [SerializeField] private FriendStateChanger _friendStateChanger;
         [SerializeField] private FormationManager _formationManager;
+        [SerializeField] private FriendOrder _friendOrder;
         [SerializeField] private bool _isWaiting;
-        [Header("TanihiraCursor")]
-        [SerializeField] private TanihiraCursor _tanihiraCursor;
         
         private Transform _currentTarget;
         private InGameManager _inGameManager;
@@ -153,7 +152,7 @@ namespace Ingame.Tanihira
                         break;
                     }
                 }
-
+                
                 if (!flag)
                 {
                     _friendStateChanger.SetMoveState();

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendStateChanger.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendStateChanger.cs
@@ -45,8 +45,23 @@ namespace Ingame.Tanihira
 
             foreach (var friend in _formationManager.FriendsList)
             {
-                friend.SetDestination(target);
-                friend.ChangeState(FriendState.Chase);
+                // 各ペンギンが規定の攻撃量を上回っていないかを判定
+                // 上回っていた場合、そのペンギンは攻撃を辞め、処理をスキップ
+                if (friend.CurrentAA >= friend.RegulationAA)
+                {
+                    // プレイヤーのところへ戻るようにする
+                    friend.SetDestination(_friendOwner.transform);
+                    friend.ChangeState(FriendState.Move);
+                    // 隊列の整理をする
+                    _formationManager.SortFormation();
+                    continue;
+                }
+
+                if (friend.IsAttackPossible)
+                {
+                    friend.SetDestination(target);
+                    friend.ChangeState(FriendState.Chase);
+                }
             }
         }
     }

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendStateChanger.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendStateChanger.cs
@@ -7,7 +7,7 @@ namespace Ingame.Tanihira
     {
         [SerializeField] private FormationManager _formationManager;
         [SerializeField] private GameObject _friendOwner;
-
+        
         public void SetMoveState()
         {
             if (_formationManager == null)
@@ -42,22 +42,10 @@ namespace Ingame.Tanihira
         {
             if (_formationManager == null || target == null)
                 return;
-
+            
             foreach (var friend in _formationManager.FriendsList)
             {
-                // 各ペンギンが規定の攻撃量を上回っていないかを判定
-                // 上回っていた場合、そのペンギンは攻撃を辞め、処理をスキップ
-                if (friend.CurrentAA >= friend.RegulationAA)
-                {
-                    // プレイヤーのところへ戻るようにする
-                    friend.SetDestination(_friendOwner.transform);
-                    friend.ChangeState(FriendState.Move);
-                    // 隊列の整理をする
-                    _formationManager.SortFormation();
-                    continue;
-                }
-
-                if (friend.IsAttackPossible)
+                if (friend.IsAttackPossible) //攻撃処理
                 {
                     friend.SetDestination(target);
                     friend.ChangeState(FriendState.Chase);

--- a/Assets/Scripts/InGame/Player/Tanihira/State/FriendAttackState.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/State/FriendAttackState.cs
@@ -18,6 +18,7 @@ namespace Ingame.Tanihira
                 friend.Agent.isStopped = true;
                 _friendObject = friend.Agent.gameObject.transform;
                 LookTarget(friend.Agent.destination);
+                friend.Agent.SetDestination(friend.Agent.destination);
             }
             friend.MecanimAnimator?.SetTrigger("Attack"); // アニメーターにAttackトリガーがある前提
         }

--- a/Assets/Scripts/InGame/Player/Tanihira/State/FriendChaseState.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/State/FriendChaseState.cs
@@ -24,9 +24,10 @@ public class FriendChaseState : IFriendState
         //速度に応じて、アニメーションを変化させる
         friend.Animator.SetFloat("MoveBlend", friend.Agent.velocity.magnitude);
         friend.ChangeRunEffect(friend.Agent.velocity.magnitude);
-
-        if (friend.Agent.remainingDistance <= friend.Agent.stoppingDistance && !friend.IsAttack)
+        
+        if (friend.Agent.remainingDistance <= friend.Agent.stoppingDistance + 0.5f && !friend.IsAttack)
         {
+            if(!friend.IsCanAttack) return;
             //エフェクトを消す
             friend.ChangeRunEffect(0.0f);
             friend.ChangeState(FriendState.Attack);

--- a/Assets/Scripts/InGame/Player/Tanihira/State/FriendChaseState.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/State/FriendChaseState.cs
@@ -18,6 +18,7 @@ public class FriendChaseState : IFriendState
     public void OnUpdate(FriendBase friend)
     {
         if (friend.Destination == null || !friend.Agent.isOnNavMesh) return;
+        if (!friend.IsAttackPossible) return;
             
         friend.Agent.SetDestination(friend.Destination.position);
         //速度に応じて、アニメーションを変化させる

--- a/Assets/Scripts/InGame/Player/Tanihira/TanihiraCursor.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/TanihiraCursor.cs
@@ -35,16 +35,9 @@ namespace Ingame.Tanihira
         private PlayerMovement _movement;
         private CameraController _cameraController;
         private FriendOrder _friendOrder;
+        private FormationManager _formationManager;
         private NetworkButtons PreviousButtons { get; set; }
         [Networked, HideInInspector] private TanihiraCursorState _state { get; set; }
-
-        /// <summary>
-        /// 指示を行ったか
-        /// true：行った
-        /// false：行っていない
-        /// </summary>
-        public bool IsInstruction;
-
 
         public override void Spawned()
         {
@@ -53,6 +46,7 @@ namespace Ingame.Tanihira
                 _playerManager = GetComponent<PlayerManager>();
                 _movement = GetComponent<PlayerMovement>();
                 _friendOrder = GetComponent<FriendOrder>();
+                _formationManager = GetComponent<FormationManager>();
                 _moveTargetInstance = Runner.Spawn(_moveTargetPrefab, Vector3.zero, Quaternion.identity);
             }
             
@@ -62,6 +56,7 @@ namespace Ingame.Tanihira
                 _playerManager = GetComponent<PlayerManager>();
                 _movement = GetComponent<PlayerMovement>();
                 _cameraController = GetComponent<CameraController>();
+                _formationManager = GetComponent<FormationManager>();
                 
                 _playerTransform = this.transform;
                 //前方最大範囲にカーソルを出現
@@ -85,12 +80,10 @@ namespace Ingame.Tanihira
             //離した時
             if (input.Buttons.WasReleased(PreviousButtons, PlayerButtons.Ability2))
             {
-                IsInstruction = false;
                 EndCursor();
             }
             else if (input.Buttons.WasPressed(PreviousButtons, PlayerButtons.Ability3) && _state == TanihiraCursorState.Active)
             {
-                IsInstruction = true;
                 MoveTargetCursor();
             }
             
@@ -138,6 +131,7 @@ namespace Ingame.Tanihira
             _moveTargetInstance.transform.position = targetPos;
             _friendOrder.ExecuteOrderMoveFriend();
             _friendOrder.AllResetAttackAmount();
+            _formationManager.SetAllAttackOrdered(true);
         }
 
         private void EndCursor()

--- a/Assets/Scripts/InGame/Player/Tanihira/TanihiraCursor.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/TanihiraCursor.cs
@@ -1,4 +1,3 @@
-using System;
 using Fusion;
 using InGame.Common;
 using InGame.Player;
@@ -38,7 +37,14 @@ namespace Ingame.Tanihira
         private FriendOrder _friendOrder;
         private NetworkButtons PreviousButtons { get; set; }
         [Networked, HideInInspector] private TanihiraCursorState _state { get; set; }
-        
+
+        /// <summary>
+        /// 指示を行ったか
+        /// true：行った
+        /// false：行っていない
+        /// </summary>
+        public bool IsInstruction;
+
 
         public override void Spawned()
         {
@@ -79,10 +85,12 @@ namespace Ingame.Tanihira
             //離した時
             if (input.Buttons.WasReleased(PreviousButtons, PlayerButtons.Ability2))
             {
+                IsInstruction = false;
                 EndCursor();
             }
             else if (input.Buttons.WasPressed(PreviousButtons, PlayerButtons.Ability3) && _state == TanihiraCursorState.Active)
             {
+                IsInstruction = true;
                 MoveTargetCursor();
             }
             
@@ -129,6 +137,7 @@ namespace Ingame.Tanihira
         {
             _moveTargetInstance.transform.position = targetPos;
             _friendOrder.ExecuteOrderMoveFriend();
+            _friendOrder.AllResetAttackAmount();
         }
 
         private void EndCursor()


### PR DESCRIPTION
・ペンギンに規定の攻撃量を設けた
・プレイヤーが指示を出すまで攻撃をしないようにした
・指示を出したのち、規定の攻撃量を超えたらプレイヤーの元へ帰還するようにした