### PR TITLE
fix: カメラのPriorityが即時反映されない問題を修正

### DIFF
--- a/Assets/Scripts/InGame/Player/CameraController.cs
+++ b/Assets/Scripts/InGame/Player/CameraController.cs
@@ -156,6 +156,10 @@ namespace InGame.Player
         public void SetCameraPriority(int priority)
         {
             _camera.Priority = priority;
+
+            // Priorityの変更を即時反映させる
+            // このメソッド自体は同じPriority同士のカメラ順序を入れ替えるためのものだが、内部的には自身をコレクションの先頭に入れなおしてからソートしているだけ
+            _camera.MoveToTopOfPrioritySubqueue();
         }
 
         public void ChangeOffset(Vector3 newOffset, float duration)


### PR DESCRIPTION
反映タイミングが1フレーム後にズレてしまう問題が発生したため、即時反映処理を追加