### PR TITLE
宝石制御用のコライダーと、カメラや飛行展示物などが衝突してしまう問題を修正

### DIFF
--- a/Assets/Prefabs/Character/Templates/PlayerBase.prefab
+++ b/Assets/Prefabs/Character/Templates/PlayerBase.prefab
@@ -5724,7 +5724,7 @@ MonoBehaviour:
   _camera: {fileID: 1140998407376993141}
   _collideAgainst:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4095
   _cameraRadius: 0.1
   _motionDuration: 0.3
   _motionEase: 9

--- a/Assets/Prefabs/Exhibit/PropAirplane.prefab
+++ b/Assets/Prefabs/Exhibit/PropAirplane.prefab
@@ -1121,7 +1121,7 @@ Rigidbody:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 4096
   m_ImplicitCom: 1
   m_ImplicitTensor: 0
   m_UseGravity: 0
@@ -1210,6 +1210,7 @@ MonoBehaviour:
   _LastInteractTime: -9999
   _LastUsedCooldownTime: 0
   _ForceSetInteractable: 1
+  _debug: 0
   _getOffPoint: {fileID: 4664626561920155601}
   _grav: 6
   _drag: {x: 0.3, y: 0.3, z: 0.1}
@@ -1241,9 +1242,12 @@ MonoBehaviour:
   _bulletMark: {fileID: 7762581465889203969, guid: 052631cb43762b9479c2428dc1d6ca4d, type: 3}
   _damageAmount: 10
   _gunMaxDistance: 1000
-  _gunLayerMask:
+  _shootingTargetLayerMask:
     serializedVersion: 2
     m_Bits: 64
+  _bulletHitLayerMask:
+    serializedVersion: 2
+    m_Bits: 4095
   _castRadius: 3
   _velocityText: {fileID: 1464172462217974093}
   _forwardSpeedText: {fileID: 793880936398018537}
@@ -1280,7 +1284,7 @@ MonoBehaviour:
   _camera: {fileID: 3659471650815562422}
   _collideAgainst:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4095
   _cameraRadius: 0.1
   _motionDuration: 1
   _motionEase: 9

--- a/Assets/Prefabs/Exhibit/Pterodactyl.prefab
+++ b/Assets/Prefabs/Exhibit/Pterodactyl.prefab
@@ -792,7 +792,7 @@ MonoBehaviour:
   _camera: {fileID: 7413664590401350041}
   _collideAgainst:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4095
   _cameraRadius: 0.1
   _motionDuration: 0.6
   _motionEase: 9
@@ -815,7 +815,7 @@ Rigidbody:
     m_Bits: 0
   m_ExcludeLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 4096
   m_ImplicitCom: 1
   m_ImplicitTensor: 0
   m_UseGravity: 0
@@ -903,6 +903,9 @@ MonoBehaviour:
   _playerHitMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  _bulletHitMask:
+    serializedVersion: 2
+    m_Bits: 4095
   _fireCooldown: 2
   _radius: 3
   _hitEffect: {fileID: 3681082649069878751, guid: 390cb52694a61f341bfe58d99efcaf7e, type: 3}
@@ -940,6 +943,7 @@ MonoBehaviour:
   _cooldownEffectTransform: {fileID: 0}
   _cooldownEffectOffset: {x: 0, y: -0.3, z: 0}
   _cooldownEffectRotation: {x: 0, y: 90, z: 0}
+  _cooldownEffectScale: {x: 1, y: 1, z: 1}
   _interactEffectType: 9
   _cooldownEffectType: 24
   _spawnCooldownEffectOnStart: 0
@@ -949,6 +953,7 @@ MonoBehaviour:
   _LastInteractTime: -9999
   _LastUsedCooldownTime: 0
   _ForceSetInteractable: 1
+  _debug: 0
   references:
     version: 2
     RefIds:

--- a/Assets/Prefabs/Exhibit/Shark.prefab
+++ b/Assets/Prefabs/Exhibit/Shark.prefab
@@ -487,7 +487,7 @@ MonoBehaviour:
   _camera: {fileID: 563758669270021188}
   _collideAgainst:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4095
   _cameraRadius: 0.1
   _motionDuration: 0.3
   _motionEase: 0

--- a/Assets/Prefabs/Exhibit/Tyranno.prefab
+++ b/Assets/Prefabs/Exhibit/Tyranno.prefab
@@ -2971,7 +2971,7 @@ MonoBehaviour:
   _camera: {fileID: 7997288692242095708}
   _collideAgainst:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4095
   _cameraRadius: 0.1
   _motionDuration: 0.3
   _motionEase: 9
@@ -3028,6 +3028,7 @@ MonoBehaviour:
   _cooldownEffectTransform: {fileID: 0}
   _cooldownEffectOffset: {x: 0.1, y: 0.1, z: 0.8}
   _cooldownEffectRotation: {x: 0, y: 0, z: 0}
+  _cooldownEffectScale: {x: 1, y: 1, z: 1}
   _interactEffectType: 9
   _cooldownEffectType: 24
   _spawnCooldownEffectOnStart: 0
@@ -3037,6 +3038,7 @@ MonoBehaviour:
   _LastInteractTime: -9999
   _LastUsedCooldownTime: 0
   _ForceSetInteractable: 1
+  _debug: 0
   references:
     version: 2
     RefIds:

--- a/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
+++ b/Assets/Scripts/InGame/Exhibit/PropAirplane.cs
@@ -12,7 +12,6 @@ using TMPro;
 using UnityEngine;
 using PlayerInput = September.Common.PlayerInput;
 using CRISound;
-using Cysharp.Threading.Tasks;
 using September.InGame.UI;
 
 namespace InGame.Exhibit
@@ -48,7 +47,8 @@ namespace InGame.Exhibit
         [SerializeField] private ParticleSystem _bulletMark;
         [SerializeField] private int _damageAmount;
         [SerializeField] private float _gunMaxDistance;
-        [SerializeField] private LayerMask _gunLayerMask = ~0;
+        [SerializeField] private LayerMask _shootingTargetLayerMask = ~0;
+        [SerializeField] private LayerMask _bulletHitLayerMask = ~0;
         [SerializeField] private float _castRadius;
         [Header("Debug")] [SerializeField] private TMP_Text _velocityText;
         [SerializeField] private TMP_Text _forwardSpeedText;
@@ -98,6 +98,7 @@ namespace InGame.Exhibit
         [SerializeField] private bool _isSpawned = false;
 
         private bool _isEnd;
+
         public override void Spawned()
         {
             _isSpawned = false;
@@ -312,7 +313,7 @@ namespace InGame.Exhibit
             _machineGunTimer = _fireInterval;
             var hits = new RaycastHit[20];
             var num = Physics.SphereCastNonAlloc(_firePoint.position, _castRadius, transform.forward, hits,
-                _gunMaxDistance, _gunLayerMask);
+                _gunMaxDistance, _shootingTargetLayerMask);
             for (int i = 0; i < num; i++)
             {
                 if(hits[i].point == Vector3.zero) continue;
@@ -333,7 +334,7 @@ namespace InGame.Exhibit
 
             foreach (var muzzle in _muzzles)
             {
-                var cast = Physics.Raycast(muzzle.position, transform.forward,out var info,_gunMaxDistance);
+                var cast = Physics.Raycast(muzzle.position, transform.forward, out var info, _gunMaxDistance, _bulletHitLayerMask);
                 RPC_PlayEffect(muzzle.position, info.point);
             }
         }

--- a/Assets/Scripts/InGame/Exhibit/PterodactylInteractable.cs
+++ b/Assets/Scripts/InGame/Exhibit/PterodactylInteractable.cs
@@ -31,8 +31,8 @@ namespace InGame.Exhibit
         [SerializeField] private float _fireSpeed = 20f;
         [SerializeField] private float _rayDistance = 100f;
 
-        [FormerlySerializedAs("_fireHitMask")] [SerializeField]
-        private LayerMask _playerHitMask;
+        [SerializeField] private LayerMask _playerHitMask;
+        [SerializeField] private LayerMask _bulletHitMask;
 
         [SerializeField] private float _fireCooldown = 2f;
         [SerializeField, Label("爆撃の有効範囲")] private float _radius = 1f;
@@ -178,7 +178,7 @@ namespace InGame.Exhibit
         {
             Vector3 angleForward = Quaternion.AngleAxis(_downwardAngle, _muzzle.right) * _muzzle.forward;
 
-            var count = Physics.RaycastNonAlloc(_muzzle.position, angleForward, _aimHits, _rayDistance);
+            var count = Physics.RaycastNonAlloc(_muzzle.position, angleForward, _aimHits, _rayDistance, _bulletHitMask);
             var closestDistance = float.MaxValue;
             var closestHit = new RaycastHit();
             var hasHit = false;


### PR DESCRIPTION
- カメラの埋まり防止処理の対象から除外
- 投射物と衝突しないように
- 飛行中の展示物と衝突しないように