### PR TITLE
宝石UIバグ修正

### DIFF
--- a/Assets/Prefabs/Character/Bot Character Okabe.prefab
+++ b/Assets/Prefabs/Character/Bot Character Okabe.prefab
@@ -167,7 +167,7 @@ PrefabInstance:
     - target: {fileID: 5053954526073002999, guid: 9d61ba56a4ca57a47b9aa55b7e1ef928, type: 3}
       propertyPath: 'NestedObjects.Array.data[1]'
       value: 
-      objectReference: {fileID: 9088071140109279762}
+      objectReference: {fileID: 2443618679467846942}
     - target: {fileID: 5053954526073002999, guid: 9d61ba56a4ca57a47b9aa55b7e1ef928, type: 3}
       propertyPath: 'NestedObjects.Array.data[2]'
       value: 
@@ -497,6 +497,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bc7840d6f50245e781522fe38dd245cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2443618679467846942 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2363092080164938730, guid: 9d61ba56a4ca57a47b9aa55b7e1ef928, type: 3}
+  m_PrefabInstance: {fileID: 81655814983880436}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &2878394974925864928 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2796741404205527316, guid: 9d61ba56a4ca57a47b9aa55b7e1ef928, type: 3}
@@ -665,16 +676,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d32d13cf9a684f21bb91c622bfe5f0c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &9088071140109279762 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 9168564727625084134, guid: 9d61ba56a4ca57a47b9aa55b7e1ef928, type: 3}
-  m_PrefabInstance: {fileID: 81655814983880436}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Character/Character Haru.prefab
+++ b/Assets/Prefabs/Character/Character Haru.prefab
@@ -4387,6 +4387,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1091560173472566822, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1844372417076586983, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0

--- a/Assets/Prefabs/Character/Character Okabe.prefab
+++ b/Assets/Prefabs/Character/Character Okabe.prefab
@@ -5252,154 +5252,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3765652809524013924, guid: f7eff99ad4d3ad74884ba6c5368b8972, type: 3}
   m_PrefabInstance: {fileID: 982348449812591428}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &6148370820579583241
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2102110813691504064}
-    m_Modifications:
-    - target: {fileID: 1109022226917107273, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_Name
-      value: JewelryCanvas
-      objectReference: {fileID: 0}
-    - target: {fileID: 3057433584865446383, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: SortKey
-      value: 1441609463
-      objectReference: {fileID: 0}
-    - target: {fileID: 7030438142900011129, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_PresetInfoIsWorld
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7278236405501402711, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7278236405501402711, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7278236405501402711, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7278236405501402711, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 1920
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 1080
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
---- !u!114 &639522504073893310 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6751860095228096695, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-  m_PrefabInstance: {fileID: 6148370820579583241}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0dbe2b9699eb99a4196b57d0c4b40c1a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &3357854975992492082 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8919970465301828923, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-  m_PrefabInstance: {fileID: 6148370820579583241}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &9168564727625084134 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3057433584865446383, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
-  m_PrefabInstance: {fileID: 6148370820579583241}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &7210946982526215258
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5408,14 +5260,6 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 49285162193059692, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_fontSize
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 49285162193059692, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_fontSizeBase
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 843966978322878472, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -5431,18 +5275,6 @@ PrefabInstance:
     - target: {fileID: 843966978322878472, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1091560173472566822, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_PresetInfoIsWorld
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1844372417076586983, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1844372417076586983, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 2447315062394318487, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: _runAnimSpeed
@@ -5459,7 +5291,7 @@ PrefabInstance:
     - target: {fileID: 2463801933549895597, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: 'NestedObjects.Array.data[1]'
       value: 
-      objectReference: {fileID: 9168564727625084134}
+      objectReference: {fileID: 2363092080164938730}
     - target: {fileID: 2525442923973757293, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: m_Avatar
       value: 
@@ -5700,29 +5532,9 @@ PrefabInstance:
       propertyPath: SortKey
       value: 2542957902
       objectReference: {fileID: 0}
-    - target: {fileID: 3228800796330585535, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 3242880713039265549, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: _staminaConsumption
       value: 21
-      objectReference: {fileID: 0}
-    - target: {fileID: 3245777783268544908, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3245777783268544908, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3245777783268544908, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0.787
-      objectReference: {fileID: 0}
-    - target: {fileID: 3245777783268544908, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3570017578186338863, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: _run
@@ -5752,10 +5564,6 @@ PrefabInstance:
       propertyPath: _layerInfo.Array.data[2].LayerMask
       value: 
       objectReference: {fileID: 31900000, guid: 1422e64155a2f1a4fafe7cd620bda205, type: 2}
-    - target: {fileID: 3839639129466349583, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: _playerJewelryView
-      value: 
-      objectReference: {fileID: 639522504073893310}
     - target: {fileID: 4102293410906870200, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: SortKey
       value: 1349920742
@@ -5764,10 +5572,6 @@ PrefabInstance:
       propertyPath: _punchEffect
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 4881938171316156394, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -0.54
-      objectReference: {fileID: 0}
     - target: {fileID: 4961011485139748784, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: SortKey
       value: 1973619447
@@ -5775,18 +5579,6 @@ PrefabInstance:
     - target: {fileID: 5365636257783601198, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: SortKey
       value: 449420672
-      objectReference: {fileID: 0}
-    - target: {fileID: 6174387095309582537, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6174387095309582537, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6174387095309582537, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7020943087661863767, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: _requiredScore
@@ -5872,10 +5664,6 @@ PrefabInstance:
       propertyPath: '_renderers.Array.data[12]'
       value: 
       objectReference: {fileID: 818250139097945691}
-    - target: {fileID: 7508249662566368237, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      propertyPath: '_hideObjects.Array.data[2]'
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 8360875997416129576, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       propertyPath: m_Name
       value: Character Okabe
@@ -5924,11 +5712,7 @@ PrefabInstance:
     m_RemovedGameObjects:
     - {fileID: 6419492589774123438, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
     - {fileID: 5396109632114098126, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-    - {fileID: 7049026060679800854, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
     m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 8736522266100138394, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
-      insertIndex: 9
-      addedObject: {fileID: 3357854975992492082}
     - targetCorrespondingSourceObject: {fileID: 8736522266100138394, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
       insertIndex: -1
       addedObject: {fileID: 4170414561756534816}
@@ -5945,6 +5729,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8736522266100138394, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
   m_PrefabInstance: {fileID: 7210946982526215258}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2363092080164938730 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4961011485139748784, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}
+  m_PrefabInstance: {fileID: 7210946982526215258}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &3305135084665881360 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: -3905644752378878134, guid: 1d232b17925a618409af4cee2aad9b7f, type: 3}

--- a/Assets/Prefabs/Character/Templates/PlayerBase.prefab
+++ b/Assets/Prefabs/Character/Templates/PlayerBase.prefab
@@ -5974,6 +5974,8 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  _walkAnimSpeed: 1
+  _runAnimSpeed: 2
   _hitReactionClip: {fileID: 7400000, guid: dc52e77d074bc11469d9ad6d72bb5654, type: 2}
   _overrideInTime: 0.08
   _overrideInCurve:
@@ -5989,7 +5991,7 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  EnableFallMotion: 1
+  _EnableFallMotion: 1
 --- !u!114 &9111916553959908344
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7288,6 +7290,10 @@ PrefabInstance:
     - target: {fileID: 3057433584865446383, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
       propertyPath: SortKey
       value: 963172361
+      objectReference: {fileID: 0}
+    - target: {fileID: 7030438142900011129, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
+      propertyPath: m_PresetInfoIsWorld
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7278236405501402711, guid: 1b7c90ad8e32a7c46b8172627e8fd6fe, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Prefabs/UI/JewelryCanvas.prefab
+++ b/Assets/Prefabs/UI/JewelryCanvas.prefab
@@ -124,7 +124,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &7116631268190812810
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Common/Extensions/GameObjectExtensions.cs
+++ b/Assets/Scripts/Common/Extensions/GameObjectExtensions.cs
@@ -1,0 +1,25 @@
+using System.Text;
+using UnityEngine;
+
+namespace Common.Extensions
+{
+    public static class GameObjectExtensions
+    {
+        public static string GetHierarchyPath(this GameObject gameObject)
+        {
+            if (gameObject == null)
+                return string.Empty;
+
+            var current = gameObject.transform;
+            var builder = new StringBuilder(current.name);
+
+            while (current.parent != null)
+            {
+                current = current.parent;
+                builder.Insert(0, current.name + "/");
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/Common/Extensions/GameObjectExtensions.cs.meta
+++ b/Assets/Scripts/Common/Extensions/GameObjectExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 862f9be719e748b98540b9c8753517e8
+timeCreated: 1784999568

--- a/Assets/Scripts/InGame/Bot/AStarSystem.cs
+++ b/Assets/Scripts/InGame/Bot/AStarSystem.cs
@@ -52,7 +52,7 @@ namespace InGame.Bot
             }
             if (startNode == null || endNode == null || nodeDatas == null)
             {
-                Debug.LogError("Œo˜H’Tõ¸”s");
+                Debug.Log("Œo˜H’Tõ¸”s");
                 _isFinding = false;
                 return new List<NodeData>();
             }

--- a/Assets/Scripts/InGame/Jewelry/JewelryPlayerHolding/PlayerJewelryRuntime.cs
+++ b/Assets/Scripts/InGame/Jewelry/JewelryPlayerHolding/PlayerJewelryRuntime.cs
@@ -85,6 +85,8 @@ namespace InGame.Jewelry
 
                 if (current == _preJewelryQuantities[i]) continue;
 
+                _preJewelryQuantities[i] = current;
+
                 var score = CalculateJewelryScore();
 
                 _onUpdateJewelryQuantity?.Invoke(JewelryType.NormalGem, score);

--- a/Assets/Scripts/InGame/Jewelry/JewelryPlayerHolding/PlayerJewelryView.cs
+++ b/Assets/Scripts/InGame/Jewelry/JewelryPlayerHolding/PlayerJewelryView.cs
@@ -2,6 +2,7 @@ using TMPro;
 using UnityEngine;
 using Fusion;
 using System;
+using Common.Extensions;
 using UnityEngine.UI;
 using InGame.Jewelry.Common;
 
@@ -37,21 +38,9 @@ namespace InGame.Jewelry
         /// <param name="sprite">アイコン</param>
         public void Init(JewelryType jewelryType, Sprite sprite)
         {
-            // 宝石の所持情報を満足に表示できない場合はreturn
-            if (_jewelryUIArray == null
-                || _jewelryUIArray.Length <= 0)
-            {
-                Debug.LogWarning("宝石UIが不足しています");
-                return;
-            }
+            if (!Validate(jewelryType)) return;
 
-            if (_jewelryUIArray.Length <= (int)jewelryType) return;
             var image = _jewelryUIArray[(int)jewelryType].JewelryImage;
-            if (image == null)
-            {
-                Debug.LogWarning("Imageコンポーネントが見つかりませんでした");
-                return;
-            }
             image.sprite = sprite;
         }
 
@@ -62,22 +51,34 @@ namespace InGame.Jewelry
         /// <param name="count">宝石の数</param>
         public void UpdateJewelryCount(JewelryType jewelryType, int count)
         {
+            if (!Validate(jewelryType)) return;
+
+            var text = _jewelryUIArray[(int)jewelryType].JewelryCountText;
+            text.text = count.ToString();
+        }
+
+        private bool Validate(JewelryType jewelryType)
+        {
             // 宝石の所持情報を満足に表示できない場合はreturn
-            if (_jewelryUIArray == null
-                || _jewelryUIArray.Length <= 0)
+            if (_jewelryUIArray == null || _jewelryUIArray.Length <= (int)jewelryType)
             {
-                Debug.LogWarning("宝石UIが不足しています");
-                return;
+                Debug.LogWarning($"宝石UIが不足しています。{(int)jewelryType}個のUIが必要です: {gameObject.GetHierarchyPath()}", this);
+                return false;
             }
 
-            if (_jewelryUIArray.Length <= (int)jewelryType) return;
-            var text = _jewelryUIArray[(int)jewelryType].JewelryCountText;
-            if (text == null)
+            if (_jewelryUIArray[(int)jewelryType].JewelryCountText == null)
             {
-                Debug.LogWarning("テキストコンポーネントが見つかりませんでした");
-                return;
+                Debug.LogWarning($"テキストコンポーネントが見つかりませんでした: {gameObject.GetHierarchyPath()}", this);
+                return false;
             }
-            text.text = count.ToString();
+
+            if (_jewelryUIArray[(int)jewelryType].JewelryImage == null)
+            {
+                Debug.LogWarning($"Imageコンポーネントが見つかりませんでした: {gameObject.GetHierarchyPath()}", this);
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Assets/Scripts/InGame/Player/PlayerRenderer.cs
+++ b/Assets/Scripts/InGame/Player/PlayerRenderer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Common.Extensions;
 using Fusion;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -86,7 +87,7 @@ namespace InGame.Player
         {
             if (playerEquipmentManager == null)
             {
-                Debug.LogWarning("Player Equipment Manager is null");
+                Debug.LogWarning($"Player Equipment Manager is null: {gameObject.GetHierarchyPath()}");
                 return;
             }
 


### PR DESCRIPTION
- オカベの宝石UIが透明化時に非表示にされない問題を修正。不要にオーバーライドされている箇所を無くして根本的に修正しました
- 宝石の数が0個になるときに更新されない問題を修正