### PR TITLE
fix: シャドウマップの大きさが不足していたので拡張した

### DIFF
--- a/Assets/Settings/PC_RPAsset.asset
+++ b/Assets/Settings/PC_RPAsset.asset
@@ -47,7 +47,7 @@ MonoBehaviour:
   m_AdditionalLightsRenderingMode: 1
   m_AdditionalLightsPerObjectLimit: 4
   m_AdditionalLightShadowsSupported: 1
-  m_AdditionalLightsShadowmapResolution: 2048
+  m_AdditionalLightsShadowmapResolution: 8192
   m_AdditionalLightsShadowResolutionTierLow: 256
   m_AdditionalLightsShadowResolutionTierMedium: 512
   m_AdditionalLightsShadowResolutionTierHigh: 1024


### PR DESCRIPTION
以下の警告ログが大量に出てきて邪魔なので拡張しました

Reduced additional punctual light shadows resolution by 4 to make 25 shadow maps fit in the 2048x2048 shadow atlas. To avoid this, increase shadow atlas size, decrease big shadow resolutions, or reduce the number of shadow maps active in the same frame
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&)

処理負荷や見た目的に変化があるかはわかりません（体感としては変わりない）