### PR TITLE
エイム中に移動入力するとガタガタする問題の修正

### DIFF
--- a/Assets/Scripts/InGame/Exhibit/Cannon/ProjectileInteractableBase.cs
+++ b/Assets/Scripts/InGame/Exhibit/Cannon/ProjectileInteractableBase.cs
@@ -152,7 +152,7 @@ namespace September.InGame.Exhibit
 			if (Runner.IsServer)
 			{
 				RPC_SetCameraPriority(CurrentUsePlayerRef, isActive ? 0 : 15);
-				_usingPlayer.RPC_SetControlState(isActive
+				_usingPlayer.SetControlState(isActive
 					? PlayerManager.PlayerControlState.Normal
 					: PlayerManager.PlayerControlState.ForcedControl);
 				_usingPlayer.RPC_SetUseGrav(isActive); 

--- a/Assets/Scripts/InGame/Player/Ability/Effect/AbilitySarutobiUlt.cs
+++ b/Assets/Scripts/InGame/Player/Ability/Effect/AbilitySarutobiUlt.cs
@@ -59,7 +59,7 @@ namespace InGame.Player.Ability.Effect
         {
             NetworkObject player = Parameter.Owner;
             _playerManager.RPC_SetUseGrav(false);
-            _playerManager.RPC_SetControlState(PlayerManager.PlayerControlState.ForcedControl);
+            _playerManager.SetControlState(PlayerManager.PlayerControlState.ForcedControl);
             _originalPosition = player.transform.position;
             _endPosition = player.transform.position + Vector3.up * _jumpHeight;
             _cameraController.ChangeOffset(_cameraOffset, 0f);
@@ -109,7 +109,7 @@ namespace InGame.Player.Ability.Effect
         {
             _rpcInvoker.RPC_ResetCameraOffset();
             _playerManager.RPC_SetUseGrav(true);
-            _playerManager.RPC_SetControlState(PlayerManager.PlayerControlState.Normal);
+            _playerManager.SetControlState(PlayerManager.PlayerControlState.Normal);
             _isLanding = false;
             _animationClipPlayerManager.EnableFallMotion = true;
         }

--- a/Assets/Scripts/InGame/Player/Ability/Effect/AbilityUltBase.cs
+++ b/Assets/Scripts/InGame/Player/Ability/Effect/AbilityUltBase.cs
@@ -67,7 +67,7 @@ namespace InGame.Player.Ability.Effect
 
             // 無敵化と入力ロック
             if (_playerHealth) _playerHealth.IsInvincible = true;
-            if (_playerManager) _playerManager.RPC_SetControlState(PlayerManager.PlayerControlState.InputLocked);
+            if (_playerManager) _playerManager.SetControlState(PlayerManager.PlayerControlState.InputLocked);
 
             OnCutInStart();
 
@@ -120,7 +120,7 @@ namespace InGame.Player.Ability.Effect
             Debug.Log("<color=yellow>[AbilityUlt]</color> CutIn End", Parameter.Owner);
             // 無敵解除と入力ロック解除
             if (_playerHealth) _playerHealth.IsInvincible = false;
-            if (_playerManager) _playerManager.RPC_SetControlState(PlayerManager.PlayerControlState.Normal);
+            if (_playerManager) _playerManager.SetControlState(PlayerManager.PlayerControlState.Normal);
 
             _isCutInEnd = true;
             OnCutInEnd();

--- a/Assets/Scripts/InGame/Player/PlayerManager.cs
+++ b/Assets/Scripts/InGame/Player/PlayerManager.cs
@@ -26,7 +26,6 @@ namespace InGame.Player
         PlayerMovement _playerMovement;
         CameraController _cameraController;
         PlayerHealth _playerHealth;
-        PlayerControlState _playerControlState = PlayerControlState.Normal;
         TickTimer _stunTickTimer;
         PlayerEffectController _playerEffectController;
         Rigidbody _rigidbody;
@@ -35,7 +34,8 @@ namespace InGame.Player
         private Quaternion _targetRotation;
         private bool _isVaultingLastFrame = false;
         private RigidbodyConstraints _defaultConstraints;
-        public PlayerControlState CurrentPlayerControlState => _playerControlState;
+
+        [Networked] public PlayerControlState CurrentPlayerControlState { get; private set; } = PlayerControlState.Normal;
 
         public void SetWarpTarget(Vector3 targetPosition, Quaternion targetRotation)
         {
@@ -144,7 +144,7 @@ namespace InGame.Player
             // プレイヤーの入力の管理
             if (_playerInputManager != null && _playerInputManager.GetPlayerInput(out var input))
             {
-                if (!IsStun && _playerControlState == PlayerControlState.Normal)
+                if (!IsStun && CurrentPlayerControlState == PlayerControlState.Normal)
                 {
                     // player movement に入力を与えて更新する_playerInputManager
                     _playerMovement.UpdateMovement(input.MoveDirection, input.Buttons.IsSet(PlayerButtons.Dash),
@@ -196,9 +196,9 @@ namespace InGame.Player
 
         public void SetControlState(PlayerControlState controlState)
         {
-            _playerControlState = controlState;
+            CurrentPlayerControlState = controlState;
 
-            if (_playerControlState == PlayerControlState.ForcedControl)
+            if (CurrentPlayerControlState == PlayerControlState.ForcedControl)
             {
                 _playerMovement.Stop();
             }
@@ -210,12 +210,6 @@ namespace InGame.Player
             if (_attackWeapon == null) return;
 
             _attackWeapon.SetActive(visible);
-        }
-
-        [Rpc(RpcSources.All, RpcTargets.All)]
-        public void RPC_SetControlState(PlayerControlState controlState)
-        {
-            SetControlState(controlState);
         }
 
         [Rpc(RpcSources.All, RpcTargets.All)]

--- a/Assets/Scripts/InGame/Player/Sarutobi/ThrowKunai.cs
+++ b/Assets/Scripts/InGame/Player/Sarutobi/ThrowKunai.cs
@@ -150,11 +150,13 @@ namespace InGame.Player.Sarutobi
                 _cameraController.ChangeOffset(_stanceCameraOffset, _changeOffsetDuration);
                 _crosshair.SetActive(true);
             }
+
+            _playerManager.SetControlState(PlayerManager.PlayerControlState.InputLocked);
+
             if (!HasStateAuthority) return;
 
             RPC_ChangeDescriptionUI(ControlDescriptionType.SarutobiAiming);
             State = KunaiStateType.Stance;
-            _playerManager.SetControlState(PlayerManager.PlayerControlState.InputLocked);
             var endType = await _clipPlayer.PlayClipAndWait(_stance);
 
             if (endType == EndClipType.Complete)


### PR DESCRIPTION
タニヒラ・サルトビのエイム中に発生するやつ

RPCじゃなくてネットワーク同期させるようにした（RPCだとクライアント予測できないので）

グラップリング挙動のほうがクライアント予測できてないけどちょっと難しいので一旦放置