### PR TITLE
タニヒラ必殺技の修正

### DIFF
--- a/Assets/Prefabs/Ability/BossPenguin.prefab
+++ b/Assets/Prefabs/Ability/BossPenguin.prefab
@@ -644,6 +644,7 @@ MonoBehaviour:
   _runEffectObject: {fileID: 6303266605181236520}
   _maxRunBlendTreeCount: 5
   _meshObject: {fileID: 6757945271084448658}
+  _movementBuffScale: 0.3
   _IsAttackOrdered:
     _value: 0
   _IsCanAttack:

--- a/Assets/Prefabs/Ability/ChildPenguin.prefab
+++ b/Assets/Prefabs/Ability/ChildPenguin.prefab
@@ -385,6 +385,7 @@ MonoBehaviour:
   _runEffectObject: {fileID: 8043574276842796753}
   _maxRunBlendTreeCount: 5
   _meshObject: {fileID: 6757945271084448658}
+  _movementBuffScale: 0.3
   _IsAttackOrdered:
     _value: 0
   _IsCanAttack:

--- a/Assets/ScriptableObjects/Friend/PenguinStatus.asset
+++ b/Assets/ScriptableObjects/Friend/PenguinStatus.asset
@@ -14,10 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _maxHealth: 50
   _attackPower: 6
-  _friendRotateSpeed: 200
+  _friendRotateSpeed: 300
   _friendFormationMoveSpeed: 7
   _friendFormationDistance: 1
   _friendChaseSpeed: 18
   _friendChaseStoppingDistance: 1
   _friendStunTime: 5
-  _friendAcceleration: 10
+  _friendAcceleration: 20

--- a/Assets/ScriptableObjects/Friend/PenguinStatus.asset
+++ b/Assets/ScriptableObjects/Friend/PenguinStatus.asset
@@ -18,6 +18,6 @@ MonoBehaviour:
   _friendFormationMoveSpeed: 7
   _friendFormationDistance: 1
   _friendChaseSpeed: 18
-  _friendChaseStopDistance: 1
+  _friendChaseStoppingDistance: 1
   _friendStunTime: 5
-  _friendAccleration: 10
+  _friendAcceleration: 10

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
@@ -359,7 +359,7 @@ namespace Ingame.Tanihira
             _currentStatus.FriendFormationSpeed *= buffRate;
             _currentStatus.FriendChaseSpeed *= buffRate;
             _currentStatus.FriendRotateSpeed *= buffRate;
-            _currentStatus.FriendAccleration *= buffRate;
+            _currentStatus.FriendAcceleration *= buffRate;
             _regulationAttackAmount = Mathf.FloorToInt(buffRate * _regulationAttackAmount);
             _currentStatus.AttackPower = (int)(_currentStatus.AttackPower * buffRate);
             ApplyStatus();
@@ -370,7 +370,7 @@ namespace Ingame.Tanihira
             _currentStatus.FriendFormationSpeed = _friendStatus.FriendFormationSpeed;
             _currentStatus.FriendChaseSpeed = _friendStatus.FriendChaseSpeed;
             _currentStatus.FriendRotateSpeed = _friendStatus.FriendRotateSpeed;
-            _currentStatus.FriendAccleration = _friendStatus.FriendAccleration;
+            _currentStatus.FriendAcceleration = _friendStatus.FriendAcceleration;
             _regulationAttackAmount = _originalRegulationAttackAmount;
             _currentStatus.AttackPower = _friendStatus.AttackPower;
             ApplyStatus();
@@ -393,7 +393,7 @@ namespace Ingame.Tanihira
             }
 
             _agent.angularSpeed = _currentStatus.FriendRotateSpeed;
-            _agent.acceleration = _currentStatus.FriendAccleration;
+            _agent.acceleration = _currentStatus.FriendAcceleration;
         }
 
         /// <summary>

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
@@ -145,15 +145,7 @@ namespace Ingame.Tanihira
             //Agentでの移動を無効かする
             _agent.updatePosition = false;
             _agent.updateRotation = false;
-            InitializeAgent();
-        }
-
-        //ステータスをnavmeshに反映
-        private void InitializeAgent()
-        {
-            _agent.angularSpeed = _currentStatus.FriendRotateSpeed;
-            _agent.speed = _currentStatus.FriendFormationSpeed;
-            _agent.acceleration = _currentStatus.FriendAccleration;
+            ApplyStatus();
         }
 
         /// <summary>
@@ -367,7 +359,6 @@ namespace Ingame.Tanihira
             _currentStatus.FriendFormationSpeed *= buffRate;
             _currentStatus.FriendChaseSpeed *= buffRate;
             _currentStatus.FriendRotateSpeed *= buffRate;
-            _currentStatus.FriendChaseDistance *= buffRate;
             _currentStatus.FriendAccleration *= buffRate;
             _regulationAttackAmount = Mathf.FloorToInt(buffRate * _regulationAttackAmount);
             _currentStatus.AttackPower = (int)(_currentStatus.AttackPower * buffRate);
@@ -378,28 +369,31 @@ namespace Ingame.Tanihira
         {
             _currentStatus.FriendFormationSpeed = _friendStatus.FriendFormationSpeed;
             _currentStatus.FriendChaseSpeed = _friendStatus.FriendChaseSpeed;
-            _currentStatus.FriendRotateSpeed *= _friendStatus.FriendRotateSpeed;
-            _currentStatus.FriendChaseDistance *= _friendStatus.FriendChaseDistance;
-            _currentStatus.FriendAccleration *= _friendStatus.FriendAccleration;
+            _currentStatus.FriendRotateSpeed = _friendStatus.FriendRotateSpeed;
+            _currentStatus.FriendAccleration = _friendStatus.FriendAccleration;
             _regulationAttackAmount = _originalRegulationAttackAmount;
             _currentStatus.AttackPower = _friendStatus.AttackPower;
             ApplyStatus();
         }
 
+        /// <summary>
+        /// 現在のステータスをAgentに反映する
+        /// </summary>
         private void ApplyStatus()
         {
             //現在のステートによってスピードを反映する
             switch (_currentState)
             {
-                case FriendState.Move:
-                    _agent.speed = _currentStatus.FriendFormationSpeed;
-                    break;
                 case FriendState.Chase:
                     _agent.speed = _currentStatus.FriendChaseSpeed;
                     break;
                 default:
+                    _agent.speed = _currentStatus.FriendFormationSpeed;
                     break;
             }
+
+            _agent.angularSpeed = _currentStatus.FriendRotateSpeed;
+            _agent.acceleration = _currentStatus.FriendAccleration;
         }
 
         /// <summary>

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendBase.cs
@@ -41,6 +41,7 @@ namespace Ingame.Tanihira
         [SerializeField] private GameObject _runEffectObject;
         [SerializeField] private float _maxRunBlendTreeCount = 5.0f;
         [SerializeField] private GameObject _meshObject;
+        [SerializeField] private float _movementBuffScale = 0.3f;
 
         [Networked] private NetworkBool HasMask { get; set; }
         [Networked] private NetworkBool HasRunEffect { get; set; }
@@ -354,14 +355,14 @@ namespace Ingame.Tanihira
             }
         }
 
-        public void StartBuff(float buffRate)
+        public void StartBuff(float speedBuffRate)
         {
-            _currentStatus.FriendFormationSpeed *= buffRate;
-            _currentStatus.FriendChaseSpeed *= buffRate;
-            _currentStatus.FriendRotateSpeed *= buffRate;
-            _currentStatus.FriendAcceleration *= buffRate;
-            _regulationAttackAmount = Mathf.FloorToInt(buffRate * _regulationAttackAmount);
-            _currentStatus.AttackPower = (int)(_currentStatus.AttackPower * buffRate);
+            _currentStatus.FriendFormationSpeed *= speedBuffRate * _movementBuffScale;
+            _currentStatus.FriendChaseSpeed *= speedBuffRate * _movementBuffScale;
+            _currentStatus.FriendRotateSpeed *= speedBuffRate * _movementBuffScale;
+            _currentStatus.FriendAcceleration *= speedBuffRate * _movementBuffScale;
+            _regulationAttackAmount = Mathf.FloorToInt(speedBuffRate * _regulationAttackAmount);
+            _currentStatus.AttackPower = (int)(_currentStatus.AttackPower * speedBuffRate);
             ApplyStatus();
         }
 

--- a/Assets/Scripts/InGame/Player/Tanihira/FriendStatus.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/FriendStatus.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Ingame.Tanihira
@@ -13,20 +11,24 @@ namespace Ingame.Tanihira
         [SerializeField] private float _friendFormationMoveSpeed = 3.5f;
         [SerializeField] private float _friendFormationDistance = 1.0f;
         [SerializeField] private float _friendChaseSpeed = 5f;
-        [SerializeField] private float _friendChaseStopDistance = 1.0f;
+        [SerializeField] private float _friendChaseStoppingDistance = 1.0f;
         [SerializeField] private float _friendStunTime = 10.0f;
-        [SerializeField] private float _friendAccleration = 10.0f;
+        [SerializeField] private float _friendAcceleration = 10.0f;
 
         public int MaxHealth { get => _maxHealth; set => _maxHealth = value; }
         public int AttackPower { get => _attackPower; set => _attackPower = value; }
         public float FriendRotateSpeed { get => _friendRotateSpeed; set => _friendRotateSpeed = value; }
+        /// <summary> 通常時の移動速度 </summary>
         public float FriendFormationSpeed { get => _friendFormationMoveSpeed; set => _friendFormationMoveSpeed = value; }
+        /// <summary> 通常時の停止距離（プレイヤーとの距離）。 </summary>
         public float FriendFormationDistance { get => _friendFormationDistance; set => _friendFormationDistance = value; }
+        /// <summary> 追跡時の移動速度 </summary>
         public float FriendChaseSpeed { get => _friendChaseSpeed; set => _friendChaseSpeed = value; }
-        public float FriendChaseDistance { get => _friendChaseStopDistance; set => _friendChaseStopDistance = value; }
+        /// <summary> 追跡時の停止距離。目標までの距離がこの値以内になれば攻撃を開始 </summary>
+        public float FriendChaseStoppingDistance { get => _friendChaseStoppingDistance; set => _friendChaseStoppingDistance = value; }
         public float FriendStunTime { get => _friendStunTime; set => _friendStunTime = value; }
-        public float FriendAccleration { get => _friendAccleration; set => _friendAccleration = value; }
-        
+        public float FriendAcceleration { get => _friendAcceleration; set => _friendAcceleration = value; }
+
         public FriendStatus Clone()
         {
             FriendStatus clone = ScriptableObject.CreateInstance<FriendStatus>();
@@ -36,9 +38,9 @@ namespace Ingame.Tanihira
             clone.FriendFormationSpeed = this.FriendFormationSpeed;
             clone.FriendFormationDistance = this.FriendFormationDistance;
             clone.FriendChaseSpeed = this.FriendChaseSpeed;
-            clone.FriendChaseDistance = this.FriendChaseDistance;
+            clone.FriendChaseStoppingDistance = this.FriendChaseStoppingDistance;
             clone.FriendStunTime = this.FriendStunTime;
-            clone.FriendAccleration = this.FriendAccleration;
+            clone.FriendAcceleration = this.FriendAcceleration;
             return clone;
         }
     }

--- a/Assets/Scripts/InGame/Player/Tanihira/State/FriendChaseState.cs
+++ b/Assets/Scripts/InGame/Player/Tanihira/State/FriendChaseState.cs
@@ -1,13 +1,11 @@
 using Ingame.Tanihira;
-using UnityEngine;
-using UnityEngine.UI;
 
 public class FriendChaseState : IFriendState
 {
     public void OnEnter(FriendBase friend)
     {
         friend.Agent.speed = friend.CurrentFriendStatus.FriendChaseSpeed;
-        friend.Agent.stoppingDistance = friend.CurrentFriendStatus.FriendChaseDistance;
+        friend.Agent.stoppingDistance = friend.CurrentFriendStatus.FriendChaseStoppingDistance;
     }
 
     public void OnExit(FriendBase friend)


### PR DESCRIPTION
必殺技中にペンギンの攻撃が当たりづらくなっていた問題を修正した
移動周りのステータスが反映されてなかったので反映されるようにした
通常時を含めたペンギンの旋回力・加減速力を向上