### PR TITLE
fix: ビルド後にステータスエフェクトが取得できないことがある問題を修正

### DIFF
--- a/Assets/Scripts/InGame/Common/StatusEffect/Common/StatusEffectsContainer.cs
+++ b/Assets/Scripts/InGame/Common/StatusEffect/Common/StatusEffectsContainer.cs
@@ -43,7 +43,7 @@ namespace InGame.Common
         {
             for (int i = 0; i < _statusEffects.Length; i++)
             {
-                if (_statusEffects[i] == statusEffect) return i;
+                if (_statusEffects[i] == statusEffect || _statusEffects[i].name == statusEffect.name) return i;
             }
 
             throw new ArgumentException(


### PR DESCRIPTION
オカベ必殺技の終了後にキャラクターアビリティが使用できなくなるバグの原因

ビルド後だと参照が変わることがあるらしいので、名前で照合するように変更