### PR TITLE
モーションのループ再生機能追加

### DIFF
--- a/Assets/Scripts/Common/Extensions/PlayableExtensions.cs
+++ b/Assets/Scripts/Common/Extensions/PlayableExtensions.cs
@@ -44,5 +44,27 @@ namespace Common.Extensions
                 }
             }
         }
+
+        /// <summary>
+        /// 自身に接続されている全てのノードを再帰的に削除します。
+        /// </summary>
+        public static void DestroyTree(this Playable root, bool destroySelf = true)
+        {
+            int count = root.GetInputCount();
+            for (int i = 0; i < count; i++)
+            {
+                Playable child = root.GetInput(i);
+                if (!child.IsValid()) continue;
+
+                if (child.GetInputCount() > 0)
+                {
+                    DestroyTree(child);
+                }
+
+                child.Destroy();
+            }
+
+            if (destroySelf) root.Destroy();
+        }
     }
 }

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Common.Extensions;
 using Cysharp.Threading.Tasks;
 using Fusion;
+using September.InGame.Common;
 using UnityEngine;
 using UnityEngine.Animations;
 using UnityEngine.Playables;
@@ -364,7 +366,7 @@ namespace InGame.Common
             _layerInfo[slot] = liOut;
 
             // 0 になったら “まだ自分が current なら” 接続解除＆破棄
-            Disconnect(layerType, played, slot);
+            DisconnectAndDestroy(layerType, played, slot);
 
             return EndClipType.Complete;
         }
@@ -403,7 +405,7 @@ namespace InGame.Common
             Play(index, forcePlay);
         }
 
-        private void Play(AnimationClip clip, LayerInfo.LayerType layerType, float weight, bool additive = false, float playSpeed = 1f)
+        private void Play(AnimationClip clip, LayerInfo.LayerType layerType, float weight, bool additive = false, float playSpeed = 1f, bool loop = false)
         {
             if (!clip) return;
 
@@ -434,11 +436,118 @@ namespace InGame.Common
             p.SetDuration(clip.length);
             p.SetSpeed(playSpeed);
 
-            _layerMixer.ConnectInput(slot, p, 0);
+            if (loop)
+            {
+                // AnimationClipPlayableの再生時間をループさせるPlayableを接続する
+                // AnimationClipPlayable -> loopPlayable -> Mixer
+                var loopPlayable = ScriptPlayable<LoopAnimationClipPlayableBehaviour>.Create(_graph, inputCount: 1);
+                loopPlayable.GetBehaviour().AnimationClipPlayable = p;
+                loopPlayable.ConnectInput(0, p, 0);
+                _layerMixer.ConnectInput(slot, loopPlayable, 0);
+            }
+            else
+            {
+                _layerMixer.ConnectInput(slot, p, 0);
+            }
             _layerMixer.SetLayerAdditive((uint)slot, additive);
             _layerMixer.SetInputWeight(slot, Mathf.Clamp01(weight));
 
             _runtimeClips[layerType] = p;
+        }
+        #endregion
+
+        #region PlayLoop
+        public void PlayClipLoop(AnimationClip clip, float speed = 1f)
+        {
+            if (!TryGetMontageIndex(clip, out int index))
+            {
+                Debug.LogWarning($"AnimationClip {clip.name} is not found in AnimationClipsContainer");
+                return;
+            }
+
+            RPC_PlayLoop(index);
+            PlayLoop(index);
+        }
+
+        [Rpc(RpcSources.All, RpcTargets.All, InvokeLocal = false)]
+        private void RPC_PlayLoop(int clipIndex)
+        {
+            PlayLoop(clipIndex);
+        }
+
+        private void PlayLoop(int clipIndex)
+        {
+            var montage = AnimationClipsContainer.Instance.AnimationMontages[clipIndex];
+            PlayLoop(montage.AnimClip, montage.TargetLayer, 1f, montage.BlendIn,
+                montage.IsAdditive, montage.PlaySpeed).Forget();
+        }
+
+        /// <summary>
+        /// 指定のアニメーションをループ再生する。
+        /// </summary>
+        /// <param name="clip">再生するアニメーション</param>
+        /// <param name="layerType">再生するレイヤーマスクの種類（ベースは不可）</param>
+        /// <param name="weight">再生するレイヤーの重み</param>
+        /// <param name="additive">加算モーションにするか</param>
+        /// <param name="playSpeed">再生速度</param>
+        /// <param name="external">外部から再生処理を止めるトークン。デフォルトではゲームオブジェクトのトークンに紐づく</param>
+        /// <param name="blendIn">アニメーション再生開始時のブレンド</param>
+        private async UniTaskVoid PlayLoop(
+            AnimationClip clip,
+            LayerInfo.LayerType layerType,
+            float weight,
+            LayerInfo.Blend blendIn,
+            bool additive = false,
+            float playSpeed = 1f,
+            CancellationToken external = default)
+        {
+            if (!clip) return;
+            if (layerType == LayerInfo.LayerType.Base)
+            {
+                Debug.LogWarning("Base レイヤーには StartLoopAnimation() できません。");
+                return;
+            }
+
+            if (!_slotOf.TryGetValue(layerType, out int slot))
+            {
+                Debug.LogWarning($"未定義のレイヤー {layerType}");
+                return;
+            }
+
+            // 同レイヤーの前回待機をキャンセルして新トークン
+            var token = RenewLayerCts(layerType, external);
+
+            var currentW = Mathf.Clamp01(_layerInfo[slot].Weight);
+            var useBlendIn = blendIn.BlendTime > 0f;
+            var startW = useBlendIn ? currentW : Mathf.Clamp01(weight);
+            var targetW = Mathf.Clamp01(weight);
+
+            Play(clip, layerType, startW, additive, playSpeed, loop: true);
+
+            var liNow = _layerInfo[slot];
+            liNow.Weight = startW;
+            _layerInfo[slot] = liNow;
+
+            // 再生中 Playable を取得
+            if (!_runtimeClips.TryGetValue(layerType, out var played) || !played.IsValid()) return;
+
+            if (useBlendIn)
+            {
+                try
+                {
+                    await BlendWeightAsync(blendIn, token, startW, targetW, slot);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                // 最終スナップ
+                _layerMixer.SetInputWeight(slot, targetW);
+                var liSnap = _layerInfo[slot];
+                liSnap.Weight = targetW;
+                _layerInfo[slot] = liSnap;
+            }
         }
         #endregion
 
@@ -734,12 +843,13 @@ namespace InGame.Common
         /// <summary>
         /// 指定のPlayableが再生中であれば、Mixerとの接続を解除したのち破棄する
         /// </summary>
-        private void Disconnect(LayerInfo.LayerType layerType, AnimationClipPlayable playable, int slot)
+        private void DisconnectAndDestroy(LayerInfo.LayerType layerType, AnimationClipPlayable playable, int slot)
         {
             if (_runtimeClips.TryGetValue(layerType, out var current) && current.Equals(playable) && current.IsValid())
             {
+                var input = _layerMixer.GetInput(slot);
                 _layerMixer.DisconnectInput(slot);
-                current.Destroy();
+                input.DestroyTree();
                 _runtimeClips.Remove(layerType);
                 _clipOf.Remove(layerType);
             }
@@ -901,7 +1011,7 @@ namespace InGame.Common
             {
                 if (!playable.IsValid()) return;
                 player.SetLayerWeight(layerType, 0);
-                player.Disconnect(layerType, playable, slot);
+                player.DisconnectAndDestroy(layerType, playable, slot);
             }
         }
         #endregion

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -40,6 +40,9 @@ namespace InGame.Common
         private readonly Dictionary<LayerInfo.LayerType, CancellationTokenSource> _layerCts = new();
         private readonly Dictionary<LayerInfo.LayerType, CancellationTokenSource> _weightBlendCts = new();
 
+        /// <summary>
+        /// 現在再生中のクリップ情報
+        /// </summary>
         private readonly Dictionary<LayerInfo.LayerType, AnimationClip> _clipOf = new();
 
         public AnimationMixerPlayable BaseMixer => _baseMixer;
@@ -360,10 +363,7 @@ namespace InGame.Common
             }
 
             // Out 完了時の最終スナップ → 0
-            _layerMixer.SetInputWeight(slot, 0f);
-            var liOut = _layerInfo[slot];
-            liOut.Weight = 0f;
-            _layerInfo[slot] = liOut;
+            SetInputWeight(slot, 0f);
 
             // 0 になったら “まだ自分が current なら” 接続解除＆破棄
             DisconnectAndDestroy(layerType, played, slot);
@@ -894,40 +894,52 @@ namespace InGame.Common
                 RPC_StopClip(index);
             }
 
-            return StopClipLocal(clip);
+            return StopClipLocal(index);
         }
 
-        [Rpc(RpcSources.All, RpcTargets.All)]
+        [Rpc(RpcSources.All, RpcTargets.All, InvokeLocal = false)]
         private void RPC_StopClip(int clipIndex)
         {
-            var montage = AnimationClipsContainer.Instance.AnimationMontages[clipIndex];
-            StopClipLocal(montage.AnimClip);
+            StopClipLocal(clipIndex);
         }
 
-        private bool StopClipLocal(AnimationClip clip)
+        private bool StopClipLocal(int clipIndex)
         {
-            foreach (var kv in _clipOf)
+            var montage = AnimationClipsContainer.Instance.AnimationMontages[clipIndex];
+            return StopClipLocal(montage.AnimClip, montage.BlendOut, destroyCancellationToken);
+        }
+
+        private bool StopClipLocal(AnimationClip clip, LayerInfo.Blend outBlend = default, CancellationToken token = default)
+        {
+            foreach ((LayerInfo.LayerType layer, AnimationClip playingClip) in _clipOf)
             {
-                if (kv.Value == clip && _runtimeClips.TryGetValue(kv.Key, out var p) && p.IsValid())
+                if (playingClip == clip && _runtimeClips.TryGetValue(layer, out var p) && p.IsValid())
                 {
-                    RenewLayerCts(kv.Key);
+                    RenewLayerCts(layer);
 
-                    _slotOf.TryGetValue(kv.Key, out int slot);
+                    _slotOf.TryGetValue(layer, out int slot);
 
-                    // レイヤーウェイトを0にリセット
-                    _layerMixer.SetInputWeight(slot, 0f);
-                    var li = _layerInfo[slot];
-                    li.Weight = 0f;
-                    _layerInfo[slot] = li;
-
-                    if (_runtimeClips.TryGetValue(kv.Key, out var prev) && prev.IsValid())
+                    if (outBlend.BlendTime > 0f)
                     {
-                        _layerMixer.DisconnectInput(slot);
-                        prev.Destroy();
+                        try
+                        {
+                            StopClipAsync(slot, layer, outBlend, token).Forget();
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            return false;
+                        }
                     }
+                    else
+                    {
+                        // レイヤーウェイトを0にリセット
+                        SetInputWeight(slot, 0f);
 
-                    _clipOf.Remove(kv.Key);
-                    _runtimeClips.Remove(kv.Key);
+                        if (_runtimeClips.TryGetValue(layer, out AnimationClipPlayable prev) && prev.IsValid())
+                        {
+                            DisconnectAndDestroy(layer, prev, slot);
+                        }
+                    }
 
                     return true;
                 }
@@ -935,6 +947,30 @@ namespace InGame.Common
 
             return false;
         }
+
+        private async UniTaskVoid StopClipAsync(int slot, LayerInfo.LayerType layer,
+            LayerInfo.Blend outBlend = default, CancellationToken token = default)
+        {
+            float from = Mathf.Clamp01(_layerInfo[slot].Weight);
+            await BlendWeightAsync(outBlend, token, from, 0, slot);
+
+            // 確実に0にする
+            SetInputWeight(slot, 0f);
+
+            if (_runtimeClips.TryGetValue(layer, out AnimationClipPlayable prev) && prev.IsValid())
+            {
+                DisconnectAndDestroy(layer, prev, slot);
+            }
+        }
+
+        private void SetInputWeight(int slot, float weight)
+        {
+            _layerMixer.SetInputWeight(slot, weight);
+            LayerInfo li = _layerInfo[slot];
+            li.Weight = weight;
+            _layerInfo[slot] = li;
+        }
+
         #endregion
 
         #region Outside Controls

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -457,7 +457,7 @@ namespace InGame.Common
         #endregion
 
         #region PlayLoop
-        public void PlayClipLoop(AnimationClip clip, float speed = 1f)
+        public void PlayClipLoop(AnimationClip clip)
         {
             if (!TryGetMontageIndex(clip, out int index))
             {

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -204,9 +204,7 @@ namespace InGame.Common
 
                 if (_runtimeClips.TryGetValue(LayerInfo.LayerType.TopLayer, out var current) && current.IsValid())
                 {
-                    _layerMixer.DisconnectInput(slot);
-                    current.Destroy();
-                    _runtimeClips.Remove(LayerInfo.LayerType.TopLayer);
+                    DisconnectAndDestroy(LayerInfo.LayerType.TopLayer, current, slot);
                 }
 
                 var li0 = _layerInfo[slot];
@@ -217,9 +215,7 @@ namespace InGame.Common
 
             if (_runtimeClips.TryGetValue(LayerInfo.LayerType.TopLayer, out var prev) && prev.IsValid())
             {
-                _layerMixer.DisconnectInput(slot);
-                prev.Destroy();
-                _runtimeClips.Remove(LayerInfo.LayerType.TopLayer);
+                DisconnectAndDestroy(LayerInfo.LayerType.TopLayer, prev, slot);
             }
 
             Play(clip, LayerInfo.LayerType.TopLayer, 1f,playSpeed: speed, additive: false);
@@ -334,14 +330,8 @@ namespace InGame.Common
                                  && _runtimeClips.TryGetValue(layerType, out var stillCurrent)
                                  && stillCurrent.Equals(played) && stillCurrent.IsValid())
                 {
-                    _layerMixer.SetInputWeight(slot, 0f);
-                    _layerMixer.DisconnectInput(slot);
-                    stillCurrent.Destroy();
-                    _runtimeClips.Remove(layerType);
-
-                    var li = _layerInfo[slot];
-                    li.Weight = 0f;
-                    _layerInfo[slot] = li;
+                    SetInputWeight(slot, 0f);
+                    DisconnectAndDestroy(layerType, stillCurrent, slot);
                 }
 
                 return EndClipType.Interrupted;
@@ -424,8 +414,7 @@ namespace InGame.Common
             // 既存接続の後片付け
             if (_runtimeClips.TryGetValue(layerType, out var prev) && prev.IsValid())
             {
-                _layerMixer.DisconnectInput(slot);
-                prev.Destroy();
+                DisconnectAndDestroy(layerType, prev, slot);
             }
 
             _clipOf[layerType] = clip;

--- a/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
+++ b/Assets/Scripts/InGame/Common/AnimationClipPlayer.cs
@@ -446,6 +446,10 @@ namespace InGame.Common
         #endregion
 
         #region PlayLoop
+        /// <summary>
+        /// <see cref="AnimationClipsContainer"/>に登録されているMontageをループ再生します。
+        /// 停止する場合は<see cref="StopClip"/>を使用してください。
+        /// </summary>
         public void PlayClipLoop(AnimationClip clip)
         {
             if (!TryGetMontageIndex(clip, out int index))

--- a/Assets/Scripts/InGame/Common/LoopAnimationClipPlayableBehaviour.cs
+++ b/Assets/Scripts/InGame/Common/LoopAnimationClipPlayableBehaviour.cs
@@ -1,0 +1,21 @@
+using UnityEngine.Animations;
+using UnityEngine.Playables;
+
+namespace September.InGame.Common
+{
+    /// <summary>
+    /// Inputに接続されたAnimationClipPlayableをループ再生します
+    /// </summary>
+    public class LoopAnimationClipPlayableBehaviour : PlayableBehaviour
+    {
+        public AnimationClipPlayable AnimationClipPlayable;
+
+        public override void PrepareFrame(Playable playable, FrameData info)
+        {
+            double duration = AnimationClipPlayable.GetDuration();
+            double time = playable.GetTime();
+
+            AnimationClipPlayable.SetTime(time % duration);
+        }
+    }
+}

--- a/Assets/Scripts/InGame/Common/LoopAnimationClipPlayableBehaviour.cs.meta
+++ b/Assets/Scripts/InGame/Common/LoopAnimationClipPlayableBehaviour.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9e22ab8a2a8145b8b1b01983c0126762
+timeCreated: 1787523624

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
@@ -43,7 +43,10 @@ namespace InGame.Common.Timeline
                     
                 _isPlayed = true;
             }
-            
+
+            // Playableが既に破棄されているかチェック
+            if (!_info.playable.IsValid()) return;
+
             var time = playable.GetTime();
             
             _info.SetTime(Mathf.Clamp((float)time, 0f, _clip.length), false);

--- a/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
+++ b/Assets/Scripts/InGame/Common/Timeline/AnimationClipPlayerPlayable.cs
@@ -30,17 +30,20 @@ namespace InGame.Common.Timeline
             }
             
             if (_clipPlayer == null || _clip == null) return;
-            
+
+            // 未再生の場合、再生を開始する
             if (!_isPlayed)
             {
                 _clipPlayer.Play(_clip);
 
+                // 生成されたPlayableを取得する
                 if (!_clipPlayer.TryGetPlayableInfo(_clip, out _info))
                 {
                     Debug.LogWarning($"AnimationClipPlayerPlayable: AnimationClipPlayable is not found (clip:{_clip.name}, _clipPlayer:{_clipPlayer})");
                     return;
                 }
-                    
+
+                // 既に再生済みとしてマーク
                 _isPlayed = true;
             }
 


### PR DESCRIPTION
## 新機能
- AnimationClipPlayer.PlayClipLoopメソッドを追加。
- StopClipで停止可能。
- ループ停止時にもモーションブレンドを可能にするため、StopClipがMontageのBlendOutを考慮するように変更。

## バグ修正
- ついでにTimeline側で破棄済みのPlayableにアクセスしてしまうバグも修正。